### PR TITLE
feat: Slot, Slottable (Render delegation 구현)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     container: pandoc/latex
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install mustache (to update the date)
         run: apk add ruby && gem install mustache

--- a/.prettierrc
+++ b/.prettierrc
@@ -5,5 +5,7 @@
   "singleQuote": true,
   "bracketSpacing": true,
   "arrowParens": "always",
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "objectWrap": "preserve",
+  "bracketSameLine": false
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -145,6 +145,7 @@ export default tseslint.config([
           caughtErrorsIgnorePattern: '^_',
         },
       ],
+      '@typescript-eslint/array-type': 'error',
     },
     settings: {
       react: {

--- a/src/shared/utils/Slot.test.tsx
+++ b/src/shared/utils/Slot.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, cleanup } from '@testing-library/react'
 import { Link, MemoryRouter } from 'react-router'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it, afterEach, beforeEach } from 'vitest'
 
 import { Slot } from './Slot'
 import { Slottable } from './Slottable'
@@ -12,34 +12,41 @@ export default function Button({
   children,
   ...restProps
 }: ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean }) {
-  const Component = asChild ? Slot : 'button'
+  const Element = asChild ? Slot : 'button'
 
   return (
-    <Component {...restProps}>
-      <Link to="/">{children}</Link>
-    </Component>
+    <Element {...restProps}>
+      <Slottable>{children}</Slottable>
+    </Element>
   )
 }
 
 describe('Slot', () => {
-  it('Slot 컴포넌트는 자식 태그를 그대로 렌더링 한다', () => {
+  afterEach(cleanup)
+
+  describe('Slot 컴포넌트는 Slottable을 통해 자식 태그를 그대로 렌더링 한다', () => {
     beforeEach(() => {
       render(
         <MemoryRouter>
           <Slot>
-            <Link to="/test">Test Link</Link>
+            <Slottable>
+              <Link to="/test">Test Link</Link>
+            </Slottable>
           </Slot>
         </MemoryRouter>,
       )
+    })
 
-      const link = screen.getByRole('link')
+    it('Slottable을 사용하여 Link를 렌더링', () => {
+      const link = screen.getByRole('link', { name: 'Test Link' })
       expect(link).toBeInTheDocument()
       expect(link.tagName).toBe('A')
       expect(link).toHaveAttribute('href', '/test')
+      expect(link).toHaveTextContent('Test Link')
     })
   })
 
-  it('asChild 옵션을 사용했을 때 Link 태그가 제대로 렌더링되는지 테스트', () => {
+  describe('asChild 옵션을 사용했을 때 Link 태그가 제대로 렌더링되는지 테스트', () => {
     beforeEach(() => {
       render(
         <MemoryRouter>
@@ -48,7 +55,9 @@ describe('Slot', () => {
           </Button>
         </MemoryRouter>,
       )
+    })
 
+    it('Link 태그가 제대로 렌더링되는지 테스트', () => {
       const anchorElement = screen.getByRole('link')
       const buttonElement = screen.queryByRole('button')
 
@@ -59,34 +68,32 @@ describe('Slot', () => {
     })
   })
 
-  it('Slottable을 이용한 일부분 위임 테스트', () => {
+  describe('Slottable을 사용하여 일부분 위임 테스트', () => {
     beforeEach(() => {
       render(
         <Slot>
-          <div>오른쪽 컴포넌트</div>
-          <Slottable>
-            <span>Slottable</span>
-          </Slottable>
           <div>왼쪽 컴포넌트</div>
+          <Slottable>
+            <button type="button">
+              <span>Slottable</span>
+            </button>
+          </Slottable>
+          <div>오른쪽 컴포넌트</div>
         </Slot>,
       )
+    })
 
+    it('Slottable을 사용하여 일부분 위임 테스트', () => {
       const slottable = screen.getByText('Slottable')
       const leftComponent = screen.getByText('왼쪽 컴포넌트')
       const rightComponent = screen.getByText('오른쪽 컴포넌트')
+      const button = screen.getByRole('button')
 
-      expect(slottable).toBeInTheDocument()
-      expect(leftComponent).toBeInTheDocument()
-      expect(rightComponent).toBeInTheDocument()
+      const slotChildren = Array.from(button?.childNodes || []).filter((node) => node.nodeType === 1)
 
-      expect(slottable.tagName).toBe('SPAN')
-
-      const parent = slottable.parentElement!
-      const children = Array.from(parent.childNodes).filter((node) => node.nodeType === 1)
-
-      expect(children[0]).toBe(rightComponent)
-      expect(children[1]).toBe(slottable)
-      expect(children[2]).toBe(leftComponent)
+      expect(slotChildren[0]).toBe(leftComponent)
+      expect(slotChildren[1]).toBe(slottable)
+      expect(slotChildren[2]).toBe(rightComponent)
     })
   })
 })

--- a/src/shared/utils/Slot.test.tsx
+++ b/src/shared/utils/Slot.test.tsx
@@ -7,11 +7,7 @@ import { Slottable } from './Slottable'
 
 import type { ButtonHTMLAttributes } from 'react'
 
-export default function Button({
-  asChild,
-  children,
-  ...restProps
-}: ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean }) {
+function Button({ asChild, children, ...restProps }: ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean }) {
   const Element = asChild ? Slot : 'button'
 
   return (

--- a/src/shared/utils/Slot.test.tsx
+++ b/src/shared/utils/Slot.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react'
+import { Link, MemoryRouter } from 'react-router'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { Slot } from './Slot'
+import { Slottable } from './Slottable'
+
+import type { ButtonHTMLAttributes } from 'react'
+
+export default function Button({
+  asChild,
+  children,
+  ...restProps
+}: ButtonHTMLAttributes<HTMLButtonElement> & { asChild?: boolean }) {
+  const Component = asChild ? Slot : 'button'
+
+  return (
+    <Component {...restProps}>
+      <Link to="/">{children}</Link>
+    </Component>
+  )
+}
+
+describe('Slot', () => {
+  it('Slot 컴포넌트는 자식 태그를 그대로 렌더링 한다', () => {
+    beforeEach(() => {
+      render(
+        <MemoryRouter>
+          <Slot>
+            <Link to="/test">Test Link</Link>
+          </Slot>
+        </MemoryRouter>,
+      )
+
+      const link = screen.getByRole('link')
+      expect(link).toBeInTheDocument()
+      expect(link.tagName).toBe('A')
+      expect(link).toHaveAttribute('href', '/test')
+    })
+  })
+
+  it('asChild 옵션을 사용했을 때 Link 태그가 제대로 렌더링되는지 테스트', () => {
+    beforeEach(() => {
+      render(
+        <MemoryRouter>
+          <Button asChild>
+            <Link to="/">Link</Link>
+          </Button>
+        </MemoryRouter>,
+      )
+
+      const anchorElement = screen.getByRole('link')
+      const buttonElement = screen.queryByRole('button')
+
+      expect(buttonElement).not.toBeInTheDocument()
+      expect(anchorElement).toBeInTheDocument()
+      expect(anchorElement).toHaveAttribute('href', '/')
+      expect(anchorElement).toHaveTextContent('Link')
+    })
+  })
+
+  it('Slottable을 이용한 일부분 위임 테스트', () => {
+    beforeEach(() => {
+      render(
+        <Slot>
+          <div>오른쪽 컴포넌트</div>
+          <Slottable>
+            <span>Slottable</span>
+          </Slottable>
+          <div>왼쪽 컴포넌트</div>
+        </Slot>,
+      )
+
+      const slottable = screen.getByText('Slottable')
+      const leftComponent = screen.getByText('왼쪽 컴포넌트')
+      const rightComponent = screen.getByText('오른쪽 컴포넌트')
+
+      expect(slottable).toBeInTheDocument()
+      expect(leftComponent).toBeInTheDocument()
+      expect(rightComponent).toBeInTheDocument()
+
+      expect(slottable.tagName).toBe('SPAN')
+
+      const parent = slottable.parentElement!
+      const children = Array.from(parent.childNodes).filter((node) => node.nodeType === 1)
+
+      expect(children[0]).toBe(rightComponent)
+      expect(children[1]).toBe(slottable)
+      expect(children[2]).toBe(leftComponent)
+    })
+  })
+})

--- a/src/shared/utils/Slot.tsx
+++ b/src/shared/utils/Slot.tsx
@@ -6,7 +6,7 @@ interface Props extends HTMLAttributes<HTMLElement> {
   children: ReactNode
 }
 
-export function Slot({ children, ...restProps }: Props) {
+export function Slot({ children, ...restProps }: Props): ReactElement | null {
   const childrenArray = Children.toArray(children)
   const slottable = childrenArray.find((child) => isValidElement(child) && child.type === Slottable) as ReactElement<{
     children: ReactNode
@@ -31,8 +31,22 @@ export function Slot({ children, ...restProps }: Props) {
       return child
     })
 
-    return isValidElement(newElement)
-      ? cloneElement(newElement, { ...restProps, ...(newElement.props as { children: ReactNode }) }, newChildren)
-      : null
+    if (!isValidElement(newElement)) {
+      return null
+    }
+
+    return cloneElement(
+      newElement as ReactElement<{ children: ReactNode }>,
+      { ...restProps, ...('props' in newElement ? (newElement.props as { children?: ReactNode }) : {}) },
+      newChildren,
+    )
   }
+
+  if (isValidElement(children)) {
+    return cloneElement(children, { ...restProps, ...(children.props as { children: ReactNode }) })
+  }
+
+  console.error('Slot 컴포넌트는 하나의 React 엘리먼트만 자식으로 받을 수 있어요.')
+
+  return null
 }

--- a/src/shared/utils/Slot.tsx
+++ b/src/shared/utils/Slot.tsx
@@ -1,0 +1,34 @@
+import { Children, cloneElement, isValidElement, type ReactElement, type ReactNode } from 'react'
+
+import { Slottable } from './Slottable'
+
+export function Slot({ children, ...restProps }: { children: ReactNode }) {
+  const childrenArray = Children.toArray(children)
+  const slottable = childrenArray.find((child) => isValidElement(child) && child.type === Slottable) as ReactElement<{
+    children: ReactNode
+  }>
+
+  if (slottable) {
+    const newElement = slottable.props.children
+    const newChildren = childrenArray.map((child) => {
+      if (child === slottable) {
+        if (Children.count(newElement) > 1) {
+          Children.only(null)
+          return
+        }
+
+        if (isValidElement(newElement)) {
+          return (newElement.props as { children: ReactNode }).children
+        }
+
+        return null
+      }
+
+      return child
+    })
+
+    return isValidElement(newElement)
+      ? cloneElement(newElement, { ...restProps, ...(newElement.props as { children: ReactNode }) }, newChildren)
+      : null
+  }
+}

--- a/src/shared/utils/Slot.tsx
+++ b/src/shared/utils/Slot.tsx
@@ -1,8 +1,12 @@
-import { Children, cloneElement, isValidElement, type ReactElement, type ReactNode } from 'react'
+import { Children, cloneElement, isValidElement, type HTMLAttributes, type ReactElement, type ReactNode } from 'react'
 
 import { Slottable } from './Slottable'
 
-export function Slot({ children, ...restProps }: { children: ReactNode }) {
+interface Props extends HTMLAttributes<HTMLElement> {
+  children: ReactNode
+}
+
+export function Slot({ children, ...restProps }: Props) {
   const childrenArray = Children.toArray(children)
   const slottable = childrenArray.find((child) => isValidElement(child) && child.type === Slottable) as ReactElement<{
     children: ReactNode

--- a/src/shared/utils/Slot.tsx
+++ b/src/shared/utils/Slot.tsx
@@ -14,6 +14,11 @@ export function Slot({ children, ...restProps }: Props): ReactElement | null {
 
   if (slottable) {
     const newElement = slottable.props.children
+
+    if (!isValidElement(newElement)) {
+      return null
+    }
+
     const newChildren = childrenArray.map((child) => {
       if (child === slottable) {
         if (Children.count(newElement) > 1) {
@@ -30,10 +35,6 @@ export function Slot({ children, ...restProps }: Props): ReactElement | null {
 
       return child
     })
-
-    if (!isValidElement(newElement)) {
-      return null
-    }
 
     return cloneElement(
       newElement as ReactElement<{ children: ReactNode }>,

--- a/src/shared/utils/Slottable.tsx
+++ b/src/shared/utils/Slottable.tsx
@@ -1,0 +1,6 @@
+/* eslint-disable react/jsx-no-useless-fragment */
+import type { ReactNode } from 'react'
+
+export function Slottable({ children }: { children: ReactNode }) {
+  return <>{children}</>
+}

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -1,1 +1,3 @@
 export * from './cn'
+export * from './Slot'
+export * from './Slottable'


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) #이슈번호, #이슈번호

- closed #33

## 📝작업 내용

### 핵심 내용
- [x] asChild 옵션을 통해 부모 컴포넌트가 자식 요소를 Slot을 이용해 대체 렌더링하도록 구현
- [x] Slottable을 사용해 특정 자식 요소만 위임 대상으로 설정하고, 나머지 자식들은 그대로 렌더링되도록 구현
- [x] Slot과 Slottable의 렌더링 방식 및 DOM 구조를 확인하는 테스트 코드 작성 완료

### 자잘한 내용
- [x] github action 버전 수정
- [x] eslint 배열, 객체 규칙 추가
- [x] prettier objectWrap 옵션 추가

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

✍🏻 참고사항
팀원들이 참고해야할 부분이 있다면 적어주세요

UI 재사용성을 위해, 적극적으로 Render Delegation을 사용해주세요!!!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * 새로운 React 컴포넌트 Slot 및 Slottable이 추가되었습니다.
  * Slot 및 Slottable 관련 테스트가 추가되었습니다.

* **Chores**
  * GitHub Actions 배포 워크플로우에서 checkout 액션 버전이 v2에서 v4로 업데이트되었습니다.
  * Prettier 설정에 새로운 포맷 옵션이 추가되었습니다.
  * ESLint 설정에 TypeScript 배열 타입 일관성 규칙이 추가되었습니다.

* **Refactor**
  * 유틸리티 모듈에서 Slot과 Slottable이 새롭게 공개 API로 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->