### PR TITLE
feat: [#54] tooltip 컴포넌트 구현

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -118,7 +118,12 @@
   --system-safe-alt: #cff6e6;
 }
 
-.tooltip:after {
+.tooltip-top:after {
   border-width: 0 10px 13px;
+  border-color: var(--gray-color-95) transparent;
+}
+
+.tooltip-bottom:after {
+  border-width: 13px 10px 0;
   border-color: var(--gray-color-95) transparent;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -117,3 +117,8 @@
   --system-safe: #31c288;
   --system-safe-alt: #cff6e6;
 }
+
+.tooltip:after {
+  border-width: 0 10px 13px;
+  border-color: var(--gray-color-95) transparent;
+}

--- a/src/shared/ui/tooltip/index.ts
+++ b/src/shared/ui/tooltip/index.ts
@@ -1,3 +1,3 @@
+export { default as Tooltip } from './tooltip'
 export { default as TooltipMessage } from './tooltip-message'
 export { default as TooltipTrigger } from './tooltip-trigger'
-export { default as Tooltip } from './tooltip'

--- a/src/shared/ui/tooltip/index.tsx
+++ b/src/shared/ui/tooltip/index.tsx
@@ -1,0 +1,3 @@
+export { default as TooltipMessage } from './tooltip-message'
+export { default as TooltipTrigger } from './tooltip-trigger'
+export { default as Tooltip } from './tooltip'

--- a/src/shared/ui/tooltip/tooltip-context.tsx
+++ b/src/shared/ui/tooltip/tooltip-context.tsx
@@ -1,0 +1,10 @@
+import { createContextScope } from '@/shared/utils'
+
+const createTooltipContext = createContextScope()
+
+export interface TooltipContextValue {
+  isShow: boolean
+  setIsShow: (hovered: boolean) => void
+}
+
+export const [TooltipProvider, useTooltipContext] = createTooltipContext<TooltipContextValue>()

--- a/src/shared/ui/tooltip/tooltip-context.tsx
+++ b/src/shared/ui/tooltip/tooltip-context.tsx
@@ -3,8 +3,10 @@ import { createContextScope } from '@/shared/utils'
 const createTooltipContext = createContextScope()
 
 export interface TooltipContextValue {
-  isShow: boolean
-  setIsShow: (hovered: boolean) => void
+  isVisible: boolean
+  setIsVisible: (hovered: boolean) => void
+  handleVisible: () => void
+  handleInvisible: () => void
 }
 
 export const [TooltipProvider, useTooltipContext] = createTooltipContext<TooltipContextValue>()

--- a/src/shared/ui/tooltip/tooltip-message.tsx
+++ b/src/shared/ui/tooltip/tooltip-message.tsx
@@ -1,10 +1,60 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+
 import { cn } from '@/shared/utils/cn'
 
 import { useTooltipContext } from './tooltip-context'
 
 import type { HTMLAttributes } from 'react'
 
-export default function TooltipMessage({ children, className }: HTMLAttributes<HTMLDivElement>) {
+const positionVariants = cva('', {
+  variants: {
+    position: {
+      top: 'bottom-10',
+      bottom: 'top-10',
+    },
+    arrowAlign: {
+      left: '-left-5',
+      center: 'left-1/2 -translate-x-1/2',
+      right: '-right-5',
+    },
+  },
+  defaultVariants: {
+    position: 'bottom',
+    arrowAlign: 'right',
+  },
+})
+
+const arrowPositionVariants = cva('', {
+  variants: {
+    arrowPosition: {
+      top: 'after:top-[-13px] tooltip-top',
+      bottom: 'after:bottom-[-13px] tooltip-bottom',
+    },
+    arrowAlign: {
+      left: 'after:left-[15px]',
+      center: 'after:left-1/2 after:-translate-x-1/2',
+      right: 'after:right-[15px]',
+    },
+  },
+  defaultVariants: {
+    arrowPosition: 'top',
+    arrowAlign: 'right',
+  },
+})
+
+interface Props
+  extends HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof positionVariants>,
+    VariantProps<typeof arrowPositionVariants> {}
+
+export default function TooltipMessage({
+  children,
+  className,
+  position,
+  arrowPosition,
+  arrowAlign,
+  ...restProps
+}: Props) {
   const { isShow } = useTooltipContext()
 
   if (!isShow) {
@@ -12,11 +62,12 @@ export default function TooltipMessage({ children, className }: HTMLAttributes<H
   }
 
   return (
-    <div className="absolute -right-5 top-10">
+    <div className={cn('absolute', positionVariants({ position, arrowAlign }))} {...restProps}>
       <div
         className={cn(
-          'relative bg-gray-95 rounded-lg p-2.5 w-fit tooltip whitespace-nowrap',
-          'after:block after:absolute  after:w-0 after:z-10  after:border-solid after:top-[-13px] after:right-[15px]',
+          'relative bg-gray-95 rounded-lg p-2.5 w-fit whitespace-nowrap',
+          'after:block after:absolute after:w-0 after:z-10 after:border-solid',
+          arrowPositionVariants({ arrowPosition, arrowAlign }),
           className,
         )}
       >

--- a/src/shared/ui/tooltip/tooltip-message.tsx
+++ b/src/shared/ui/tooltip/tooltip-message.tsx
@@ -70,6 +70,8 @@ export default function TooltipMessage({
           arrowPositionVariants({ arrowPosition, arrowAlign }),
           className,
         )}
+        role="tooltip"
+        aria-live="polite"
       >
         <span className="text-gray-5 font-normal text-sm">{children}</span>
       </div>

--- a/src/shared/ui/tooltip/tooltip-message.tsx
+++ b/src/shared/ui/tooltip/tooltip-message.tsx
@@ -2,6 +2,8 @@ import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '@/shared/utils/cn'
 
+import Text from '../text/text'
+
 import { useTooltipContext } from './tooltip-context'
 
 import type { HTMLAttributes } from 'react'
@@ -73,7 +75,9 @@ export default function TooltipMessage({
         role="tooltip"
         aria-live="polite"
       >
-        <span className="text-gray-5 font-normal text-sm">{children}</span>
+        <Text typography="label" className="text-gray-20">
+          {children}
+        </Text>
       </div>
     </div>
   )

--- a/src/shared/ui/tooltip/tooltip-message.tsx
+++ b/src/shared/ui/tooltip/tooltip-message.tsx
@@ -1,0 +1,27 @@
+import { cn } from '@/shared/utils/cn'
+
+import { useTooltipContext } from './tooltip-context'
+
+import type { HTMLAttributes } from 'react'
+
+export default function TooltipMessage({ children, className }: HTMLAttributes<HTMLDivElement>) {
+  const { isShow } = useTooltipContext()
+
+  if (!isShow) {
+    return null
+  }
+
+  return (
+    <div className="absolute -right-9 top-10">
+      <div
+        className={cn(
+          'relative bg-gray-95 rounded-lg p-2.5 w-fit tooltip whitespace-nowrap',
+          'after:block after:absolute  after:w-0 after:z-10  after:border-solid after:top-[-13px] after:left-[75%]',
+          className,
+        )}
+      >
+        <span className="text-gray-5 font-normal text-sm">{children}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/shared/ui/tooltip/tooltip-message.tsx
+++ b/src/shared/ui/tooltip/tooltip-message.tsx
@@ -12,11 +12,11 @@ export default function TooltipMessage({ children, className }: HTMLAttributes<H
   }
 
   return (
-    <div className="absolute -right-9 top-10">
+    <div className="absolute -right-5 top-10">
       <div
         className={cn(
           'relative bg-gray-95 rounded-lg p-2.5 w-fit tooltip whitespace-nowrap',
-          'after:block after:absolute  after:w-0 after:z-10  after:border-solid after:top-[-13px] after:left-[75%]',
+          'after:block after:absolute  after:w-0 after:z-10  after:border-solid after:top-[-13px] after:right-[15px]',
           className,
         )}
       >

--- a/src/shared/ui/tooltip/tooltip-message.tsx
+++ b/src/shared/ui/tooltip/tooltip-message.tsx
@@ -26,23 +26,26 @@ const positionVariants = cva('', {
   },
 })
 
-const arrowPositionVariants = cva('', {
-  variants: {
-    arrowPosition: {
-      top: 'after:top-[-13px] tooltip-top',
-      bottom: 'after:bottom-[-13px] tooltip-bottom',
+const arrowPositionVariants = cva(
+  'relative bg-gray-95 rounded-lg p-2.5 w-fit whitespace-nowrap after:block after:absolute after:w-0 after:z-10 after:border-solid',
+  {
+    variants: {
+      arrowPosition: {
+        top: 'after:top-[-13px] tooltip-top',
+        bottom: 'after:bottom-[-13px] tooltip-bottom',
+      },
+      arrowAlign: {
+        left: 'after:left-[15px]',
+        center: 'after:left-1/2 after:-translate-x-1/2',
+        right: 'after:right-[15px]',
+      },
     },
-    arrowAlign: {
-      left: 'after:left-[15px]',
-      center: 'after:left-1/2 after:-translate-x-1/2',
-      right: 'after:right-[15px]',
+    defaultVariants: {
+      arrowPosition: 'top',
+      arrowAlign: 'right',
     },
   },
-  defaultVariants: {
-    arrowPosition: 'top',
-    arrowAlign: 'right',
-  },
-})
+)
 
 interface Props
   extends HTMLAttributes<HTMLDivElement>,
@@ -57,7 +60,7 @@ export default function TooltipMessage({
   arrowAlign,
   ...restProps
 }: Props) {
-  const { isShow } = useTooltipContext()
+  const { isVisible: isShow } = useTooltipContext()
 
   if (!isShow) {
     return null
@@ -66,12 +69,7 @@ export default function TooltipMessage({
   return (
     <div className={cn('absolute', positionVariants({ position, arrowAlign }))} {...restProps}>
       <div
-        className={cn(
-          'relative bg-gray-95 rounded-lg p-2.5 w-fit whitespace-nowrap',
-          'after:block after:absolute after:w-0 after:z-10 after:border-solid',
-          arrowPositionVariants({ arrowPosition, arrowAlign }),
-          className,
-        )}
+        className={cn(arrowPositionVariants({ arrowPosition, arrowAlign }), className)}
         role="tooltip"
         aria-live="polite"
       >

--- a/src/shared/ui/tooltip/tooltip-trigger.tsx
+++ b/src/shared/ui/tooltip/tooltip-trigger.tsx
@@ -2,23 +2,19 @@ import { useTooltipContext } from './tooltip-context'
 
 import type { ButtonHTMLAttributes } from 'react'
 
-export default function TooltipTrigger({ children }: ButtonHTMLAttributes<HTMLButtonElement>) {
-  const { setIsShow } = useTooltipContext()
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {}
 
-  const handleTooltipOpen = () => {
-    setIsShow(true)
-  }
-
-  const handleTooltipClose = () => {
-    setIsShow(false)
-  }
+export default function TooltipTrigger({ children, ...restProps }: Props) {
+  const { handleInvisible, handleVisible } = useTooltipContext()
 
   return (
     <button
       type="button"
-      onClick={handleTooltipOpen}
-      onMouseEnter={handleTooltipOpen}
-      onMouseLeave={handleTooltipClose}
+      onClick={handleVisible}
+      onMouseEnter={handleVisible}
+      onMouseLeave={handleInvisible}
+      {...restProps}
     >
       {children}
     </button>

--- a/src/shared/ui/tooltip/tooltip-trigger.tsx
+++ b/src/shared/ui/tooltip/tooltip-trigger.tsx
@@ -1,0 +1,26 @@
+import { useTooltipContext } from './tooltip-context'
+
+import type { ButtonHTMLAttributes } from 'react'
+
+export default function TooltipTrigger({ children }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  const { setIsShow } = useTooltipContext()
+
+  const handleTooltipOpen = () => {
+    setIsShow(true)
+  }
+
+  const handleTooltipClose = () => {
+    setIsShow(false)
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleTooltipOpen}
+      onMouseEnter={handleTooltipOpen}
+      onMouseLeave={handleTooltipClose}
+    >
+      {children}
+    </button>
+  )
+}

--- a/src/shared/ui/tooltip/tooltip.test.tsx
+++ b/src/shared/ui/tooltip/tooltip.test.tsx
@@ -1,0 +1,37 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { afterEach, describe, it, expect } from 'vitest'
+
+import Tooltip from './tooltip'
+import TooltipMessage from './tooltip-message'
+import TooltipTrigger from './tooltip-trigger'
+
+function TestTooltip() {
+  return (
+    <Tooltip>
+      <TooltipTrigger>?</TooltipTrigger>
+      <TooltipMessage>툴팁 테스트 메시지</TooltipMessage>
+    </Tooltip>
+  )
+}
+
+describe('틀팁 메시지', () => {
+  afterEach(cleanup)
+
+  it('trigger에 이벤트가 없을때 메시지 미출력 테스트', async () => {
+    render(<TestTooltip />)
+
+    expect(screen.queryByText('툴팁 테스트 메시지')).not.toBeInTheDocument()
+  })
+
+  it('trigger에 Hover시 메시지 출력 테스트', async () => {
+    const user = userEvent.setup()
+
+    render(<TestTooltip />)
+
+    const trigger = screen.getByRole('button', { name: '?' })
+    await user.hover(trigger)
+
+    expect(screen.getByText('툴팁 테스트 메시지')).toBeInTheDocument()
+  })
+})

--- a/src/shared/ui/tooltip/tooltip.tsx
+++ b/src/shared/ui/tooltip/tooltip.tsx
@@ -23,8 +23,16 @@ import { TooltipProvider } from './tooltip-context'
 export default function Tooltip({ children, className, ...restProps }: HTMLAttributes<HTMLDivElement>) {
   const [isShow, setIsShow] = useState<boolean>(false)
 
+  const handleVisible = () => {
+    setIsShow(true)
+  }
+
+  const handleInvisible = () => {
+    setIsShow(false)
+  }
+
   return (
-    <TooltipProvider value={{ isShow, setIsShow }}>
+    <TooltipProvider value={{ isVisible: isShow, setIsVisible: setIsShow, handleVisible, handleInvisible }}>
       <div className={cn('relative w-fit', className)} {...restProps}>
         {children}
       </div>

--- a/src/shared/ui/tooltip/tooltip.tsx
+++ b/src/shared/ui/tooltip/tooltip.tsx
@@ -20,12 +20,14 @@ import { TooltipProvider } from './tooltip-context'
  *  <TooltipMessage>툴팁 메시지입니다</TooltipMessage>
  * </Tooltip>
  */
-export default function Tooltip({ children, className }: HTMLAttributes<HTMLDivElement>) {
+export default function Tooltip({ children, className, ...restProps }: HTMLAttributes<HTMLDivElement>) {
   const [isShow, setIsShow] = useState<boolean>(false)
 
   return (
     <TooltipProvider value={{ isShow, setIsShow }}>
-      <div className={cn('relative w-fit', className)}>{children}</div>
+      <div className={cn('relative w-fit', className)} {...restProps}>
+        {children}
+      </div>
     </TooltipProvider>
   )
 }

--- a/src/shared/ui/tooltip/tooltip.tsx
+++ b/src/shared/ui/tooltip/tooltip.tsx
@@ -4,6 +4,22 @@ import { cn } from '@/shared/utils'
 
 import { TooltipProvider } from './tooltip-context'
 
+/**
+ * Tooltip 컴포넌트
+ *
+ * @param {import('react').HTMLAttributes<HTMLDivElement>} props - div의 기본 속성들 (className, children 등)
+ * @param {React.ReactNode} props.children - TooltipTrigger, TooltipMessage 등 하위 컴포넌트들
+ * @param {string} [props.className] - 추가로 적용할 CSS 클래스 이름
+ * @returns {JSX.Element} Tooltip 상태를 Context로 감싸 렌더링하는 div
+ *
+ * @example
+ * <Tooltip>
+ *  <TooltipTrigger>
+ *    <IconClose/>
+ *  </TooltipTrigger>
+ *  <TooltipMessage>툴팁 메시지입니다</TooltipMessage>
+ * </Tooltip>
+ */
 export default function Tooltip({ children, className }: HTMLAttributes<HTMLDivElement>) {
   const [isShow, setIsShow] = useState<boolean>(false)
 

--- a/src/shared/ui/tooltip/tooltip.tsx
+++ b/src/shared/ui/tooltip/tooltip.tsx
@@ -1,0 +1,15 @@
+import { useState, type HTMLAttributes } from 'react'
+
+import { cn } from '@/shared/utils'
+
+import { TooltipProvider } from './tooltip-context'
+
+export default function Tooltip({ children, className }: HTMLAttributes<HTMLDivElement>) {
+  const [isShow, setIsShow] = useState<boolean>(false)
+
+  return (
+    <TooltipProvider value={{ isShow, setIsShow }}>
+      <div className={cn('relative w-fit', className)}>{children}</div>
+    </TooltipProvider>
+  )
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

- close #54

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 컴파운드 패턴으로 툴팁 컴포넌트 및 하위 컴포넌트 구현
- context 기반 상태관리로 툴팁 표시 제어
- 테스트 코드 작성


## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

### 메시지가 길 때
<img width="333" height="131" alt="스크린샷 2025-07-15 오전 9 27 56" src="https://github.com/user-attachments/assets/dd958a99-b6d5-4067-b2ff-20f1e0ded00b" />

### 메시지가 짧을 때
<img width="139" height="116" alt="스크린샷 2025-07-15 오전 9 27 39" src="https://github.com/user-attachments/assets/c600115b-cf0c-4761-bce4-0f8511663623" />



## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ


## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

툴팁 메시지는 활용도가 높을 것 같아서 툴팁 트리거 컴포넌트를 별도로 만들어 다양한 요소를 트리거로 사용할 수 있도록 했습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 툴팁 컴포넌트가 추가되어 버튼 등에서 마우스를 올리거나 클릭 시 설명 메시지를 표시할 수 있습니다.
  * 툴팁의 위치와 화살표 방향, 정렬을 다양하게 설정할 수 있습니다.

* **스타일**
  * 툴팁 화살표의 상단 및 하단 위치에 대한 새로운 CSS 스타일이 추가되었습니다.

* **테스트**
  * 툴팁 컴포넌트의 동작(표시/숨김)에 대한 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->