### PR TITLE
feat: [#62] select 컴포넌트 구현

### DIFF
--- a/src/shared/hooks/use-select-context.ts
+++ b/src/shared/hooks/use-select-context.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react'
+
+import SelectContext from '../ui/select/select-context'
+
+export default function useSelectContext() {
+  const context = useContext(SelectContext)
+  if (!context) {
+    throw new Error('Select components must be used within a <SelectProvider>')
+  }
+  return context
+}

--- a/src/shared/ui/select/index.ts
+++ b/src/shared/ui/select/index.ts
@@ -1,0 +1,12 @@
+import Select from './select'
+import SelectContent from './select-content'
+import SelectOption from './select-option'
+import SelectTrigger from './select-trigger'
+
+const SelectCompound = Object.assign(Select, {
+  Trigger: SelectTrigger,
+  Content: SelectContent,
+  Option: SelectOption,
+})
+
+export default SelectCompound

--- a/src/shared/ui/select/select-content.tsx
+++ b/src/shared/ui/select/select-content.tsx
@@ -1,0 +1,16 @@
+import useSelectContext from '../../hooks/use-select-context'
+
+import type { HtmlHTMLAttributes, ReactNode } from 'react'
+
+interface Props extends HtmlHTMLAttributes<HTMLUListElement> {
+  children : ReactNode
+}
+
+export default function SelectContent( { children, ...restProps }: Props) {
+  const { isOpen } = useSelectContext()
+  if (!isOpen) {
+    return null
+  }
+
+  return <ul {...restProps}>{children}</ul>
+}

--- a/src/shared/ui/select/select-context.tsx
+++ b/src/shared/ui/select/select-context.tsx
@@ -1,0 +1,11 @@
+import { createContext } from 'react'
+
+export interface SelectContextType {
+    isOpen: boolean
+    toggleOpen: () => void
+    selectedValue: string | null
+    selectValue: (value: string) => void
+}
+
+const SelectContext = createContext<SelectContextType | undefined>(undefined)
+export default SelectContext

--- a/src/shared/ui/select/select-option.tsx
+++ b/src/shared/ui/select/select-option.tsx
@@ -1,0 +1,25 @@
+import useSelectContext from '../../hooks/use-select-context'
+
+import type { HTMLAttributes, KeyboardEvent } from 'react'
+
+interface Props extends HTMLAttributes<HTMLLIElement> {
+    value: string
+}
+
+export default function SelectOption({ value, children, ...props } : Props) {
+  const { selectValue, selectedValue } = useSelectContext()
+
+  const handleClick = () => {
+    selectValue(value)
+  }
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      handleClick()
+    }
+  }
+
+  return (
+    <li role='option' aria-selected={selectedValue === value} tabIndex={0} onClick={handleClick} onKeyDown={handleKeyDown} {...props}>{children}</li>
+  )
+}

--- a/src/shared/ui/select/select-provider.tsx
+++ b/src/shared/ui/select/select-provider.tsx
@@ -1,0 +1,27 @@
+import { useState, type ReactNode } from 'react'
+
+import SelectContext, { type SelectContextType } from './select-context'
+
+interface Props {
+  children: ReactNode
+  defaultValue?: string | null
+}
+
+export default function SelectProvider({ children, defaultValue = null }: Props) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [selectedValue, setSelectedValue] = useState<string | null>(defaultValue)
+
+  const toggleOpen = () => setIsOpen(prev => !prev)
+  const selectValue = (value: string) => {
+    setSelectedValue(value)
+    setIsOpen(false)
+  }
+
+  const value: SelectContextType = { isOpen, toggleOpen, selectedValue, selectValue }
+
+  return (
+    <SelectContext.Provider value={value}>
+      {children}
+    </SelectContext.Provider>
+  )
+}

--- a/src/shared/ui/select/select-trigger.tsx
+++ b/src/shared/ui/select/select-trigger.tsx
@@ -1,0 +1,11 @@
+import useSelectContext from '../../hooks/use-select-context'
+
+import type { ButtonHTMLAttributes } from 'react'
+
+export default function SelectTrigger(props: ButtonHTMLAttributes<HTMLButtonElement>) {
+  const { toggleOpen } = useSelectContext()
+
+  return (
+    <button type='button' onClick={toggleOpen} {...props} />
+  )
+}

--- a/src/shared/ui/select/select.tsx
+++ b/src/shared/ui/select/select.tsx
@@ -1,0 +1,16 @@
+import SelectProvider from './select-provider'
+
+import type { ReactNode } from 'react'
+
+interface Props {
+    children: ReactNode
+    defaultValue?: string
+}
+
+export default function Select({ children, defaultValue } : Props) {
+  return (
+    <SelectProvider defaultValue={defaultValue}>
+      {children}
+    </SelectProvider>
+  )
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#62 

ㅤ

## 📝 작업 내용

- [x] SelectBox 컴포넌트 작업
- [ ] JSDoc 함수 주석 작성
- [ ] 테스트 코드 작성

ㅤ

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항

- dropdown컴포넌트의 'menu'와 'menu-item'과 이름을 통일할지 고민하다가 'content'와 'option'으로 만들었습니다.
- 동현님이 만드신 modal의 index.ts는 개별 export만 돼 있어서 그렇게 만들어야 하나 했는데 select랑 dropdown은 하위 컴포넌트를 하나의 루트에 종속시키는 형식이라 compound방식을 사용하는게 좋다고 하길래 compound방식으로 작성했습니다.
- 주석과 테스트 코드는 아직 작성하지 못했습니다.

ㅤ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 커스텀 Select UI 컴포넌트가 추가되었습니다. Select, SelectTrigger, SelectContent, SelectOption 등 다양한 하위 컴포넌트와 컨텍스트 기반 상태 관리가 포함되어 있습니다.
  * Select 드롭다운 열기/닫기, 옵션 선택 및 기본값 지정 기능이 제공됩니다.
  * 키보드 및 마우스 인터랙션, 접근성 속성이 적용되어 사용성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->