### PR TITLE
fix: [#79] form 테스트 코드 수정

### DIFF
--- a/src/shared/ui/form/form-field.tsx
+++ b/src/shared/ui/form/form-field.tsx
@@ -1,7 +1,7 @@
 import { ErrorMessage } from '@hookform/error-message'
 import { useFormContext } from 'react-hook-form'
 
-import { cn } from '../../utils'
+import { cn } from '@/shared/utils'
 
 import FormErrorMessage from './form-error-message'
 import { FormFieldProvider } from './form-field-context'
@@ -16,13 +16,13 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
  * <label + input + 에러 메시지> 를 묶은 폼 필드 컴포넌트
  * @param {object} props
  * @param {string} props.name - label과 input을 연결하는 name 속성
- * @param {string} props.label - label에 표시될 텍스트
  * @param {string | undefined} props.className - 추가적으로 추가할 class
- * @param {React.ReactNode} props.children - input, textarea 등 자식 요소
+ * @param {React.ReactNode} props.children - label, input, textarea 등 자식 요소
  *
  * @example
- * <FormField name='email' label='이메일'>
- *      <FormInput name='email' placeholder='이메일을 입력해주세요' />
+ * <FormField name='email'>
+ *  <FormLabel>이메일</FormLabel>
+ *  <FormInput placeholder='이메일을 입력해주세요' />
  * </FormField>
  *
  * @returns {JSX.Element}

--- a/src/shared/ui/form/form.test.tsx
+++ b/src/shared/ui/form/form.test.tsx
@@ -8,6 +8,7 @@ import Form from './form'
 import FormField from './form-field'
 import FormInput from './form-input'
 import FormSubmit from './form-submit'
+import FormLabel from './form-label'
 
 const TestSchema = z.object({
   email: z.string().email({ message: '이메일 형식으로 입력해주세요' }),
@@ -19,11 +20,14 @@ const handleSubmitMock = vi.fn()
 function TestForm() {
   return (
     <Form resolver={zodResolver(TestSchema)} onSubmit={handleSubmitMock}>
-      <FormField name="email" label="이메일">
-        <FormInput name="email" />
+      <FormField name="email" >
+        <FormLabel>이메일</FormLabel>
+        
+        <FormInput  placeholder='이메일을 입력하세요'/>
       </FormField>
-      <FormField name="password" label="패스워드">
-        <FormInput name="password" />
+      <FormField name="password" >
+        <FormLabel>패스워드</FormLabel>
+        <FormInput  placeholder='비밀번호를 입력하세요'/>
       </FormField>
       <FormSubmit>제출</FormSubmit>
     </Form>
@@ -79,10 +83,12 @@ describe('폼 컴포넌트', () => {
 
     render(
       <Form resolver={zodResolver(TestSchema)} onSubmit={handleSubmitMock} defaultValues={initialValues}>
-        <FormField name="email" label="이메일">
+        <FormField name="email">
+          <FormLabel>이메일</FormLabel>
           <FormInput name="email" />
         </FormField>
-        <FormField name="password" label="패스워드">
+        <FormField name="password" >
+          <FormLabel>패스워드</FormLabel>
           <FormInput name="password" />
         </FormField>
         <FormSubmit>제출</FormSubmit>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

- close #79

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

form field 코드 수정으로 인해 테스트가 실패하여, 테스트 코드의 폼 컴포넌트 수정

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

ㅤ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서화**
  * `FormField` 컴포넌트의 JSDoc 문서에서 `label` prop 관련 내용을 제거하고, 예시를 `FormLabel`과 `FormInput` 자식 요소를 사용하는 방식으로 수정했습니다.

* **테스트**
  * 테스트에서 `FormField`의 `label` prop 사용을 제거하고, 대신 `FormLabel` 컴포넌트를 명시적으로 추가했습니다.
  * 이메일과 비밀번호 입력 필드에 placeholder 텍스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->