### PR TITLE
refactor: [#97] form 컴포넌트 Prop 수정

### DIFF
--- a/src/shared/ui/form/form.test.tsx
+++ b/src/shared/ui/form/form.test.tsx
@@ -1,6 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { useForm } from 'react-hook-form'
 import { describe, it, vi, expect, afterEach, beforeEach } from 'vitest'
 import * as z from 'zod'
 
@@ -15,11 +16,18 @@ const TestSchema = z.object({
   password: z.string().min(8, { message: '비밀번호는 8자 이상 입력해주세요' }),
 })
 
+type TestType = z.infer<typeof TestSchema>
+
 const handleSubmitMock = vi.fn()
 
 function TestForm() {
+  const methods = useForm<TestType>({
+    resolver: zodResolver(TestSchema),
+    mode: 'onChange',
+  })
+
   return (
-    <Form resolver={zodResolver(TestSchema)} onSubmit={handleSubmitMock}>
+    <Form methods={methods} onSubmit={handleSubmitMock}>
       <FormField name="email">
         <FormLabel>이메일</FormLabel>
         <FormInput placeholder="이메일을 입력하세요" />
@@ -27,6 +35,34 @@ function TestForm() {
       <FormField name="password">
         <FormLabel>패스워드</FormLabel>
         <FormInput placeholder="비밀번호를 입력하세요" />
+      </FormField>
+      <FormSubmit>제출</FormSubmit>
+    </Form>
+  )
+}
+
+// eslint-disable-next-line react/no-multi-comp
+function TestDefaultForm() {
+  const initialValues = {
+    email: 'init@example.com',
+    password: 'initpass123',
+  }
+
+  const methods = useForm<TestType>({
+    resolver: zodResolver(TestSchema),
+    mode: 'onChange',
+    defaultValues: initialValues,
+  })
+
+  return (
+    <Form methods={methods} onSubmit={handleSubmitMock}>
+      <FormField name="email">
+        <FormLabel>이메일</FormLabel>
+        <FormInput name="email" />
+      </FormField>
+      <FormField name="password">
+        <FormLabel>패스워드</FormLabel>
+        <FormInput name="password" />
       </FormField>
       <FormSubmit>제출</FormSubmit>
     </Form>
@@ -78,19 +114,7 @@ describe('폼 컴포넌트', () => {
       password: 'initpass123',
     }
 
-    render(
-      <Form resolver={zodResolver(TestSchema)} onSubmit={handleSubmitMock} defaultValues={initialValues}>
-        <FormField name="email">
-          <FormLabel>이메일</FormLabel>
-          <FormInput name="email" />
-        </FormField>
-        <FormField name="password">
-          <FormLabel>패스워드</FormLabel>
-          <FormInput name="password" />
-        </FormField>
-        <FormSubmit>제출</FormSubmit>
-      </Form>,
-    )
+    render(<TestDefaultForm />)
 
     expect(screen.getByLabelText(/이메일/)).toHaveValue(initialValues.email)
     expect(screen.getByLabelText(/패스워드/)).toHaveValue(initialValues.password)

--- a/src/shared/ui/form/form.tsx
+++ b/src/shared/ui/form/form.tsx
@@ -1,13 +1,12 @@
-import { useForm, FormProvider, type UseFormProps, type Resolver, type FieldValues } from 'react-hook-form'
+import { FormProvider, type UseFormProps, type FieldValues, type UseFormReturn } from 'react-hook-form'
 
 import { cn } from '../../utils'
 
 import type { ReactNode } from 'react'
 
 interface Props<T extends FieldValues> extends UseFormProps<T> {
-  resolver: Resolver<T>
   children: ReactNode
-
+  methods: UseFormReturn<T>
   onSubmit: (_data: T) => void
   className?: string
 }
@@ -15,26 +14,21 @@ interface Props<T extends FieldValues> extends UseFormProps<T> {
 /**
  * @template T - 폼 데이터 타입 (react-hook-form FieldValues 확장)
  * @param {object} props
- * @param {Resolver<T>} props.resolver - zod 스키마를 기반으로 생성한 react-hook-form 유효성 검사 함수
+ * @param {UseFormReturn<T>} methods - react-hook-form useForm 훅에서 반환된 메서드와 상태 객체
  * @param {ReactNode} props.children - 폼 내부에 렌더링할 자식 컴포넌트 (title, input, field 등)
  * @param {data: T} props.onSubmit - 폼 제출 시 실행되는 함수, 폼 데이터를 인자로 받음
  * @param {string | undefined} props.className - 추가적으로 적용할 CSS 클래스명
  */
 export default function Form<T extends FieldValues>({
-  resolver,
+  methods,
   onSubmit,
   children,
   className,
   ...restProps
 }: Props<T>) {
-  const methods = useForm<T>({
-    resolver,
-    ...restProps,
-  })
-
   return (
     <FormProvider {...methods}>
-      <form onSubmit={methods.handleSubmit(onSubmit)} className={cn('flex flex-col', className)}>
+      <form onSubmit={methods.handleSubmit(onSubmit)} className={cn('flex flex-col', className)} {...restProps}>
         {children}
       </form>
     </FormProvider>

--- a/src/shared/ui/input/input.test.tsx
+++ b/src/shared/ui/input/input.test.tsx
@@ -1,6 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { useForm } from 'react-hook-form'
 import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
 import z from 'zod'
 
@@ -17,8 +18,15 @@ function TestInput() {
 
   const handleSubmit = vi.fn()
 
+  type TestType = z.infer<typeof TestSchema>
+
+  const methods = useForm<TestType>({
+    resolver: zodResolver(TestSchema),
+    mode: 'onChange',
+  })
+
   return (
-    <Form resolver={zodResolver(TestSchema)} onSubmit={handleSubmit}>
+    <Form methods={methods} onSubmit={handleSubmit}>
       <Input name="email" placeholder="이메일을 입력해주세요" />
       <PasswordInput name="password" />
     </Form>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

- close #97

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

기존에는 resolver 객체만 받아와서 form provider 안에서 useForm 객체를 생성했었는데,
이게 잘못된 방법..이란걸 깨닫고
Form 컴포넌트를 조합해서 사용하는 상위 컴포넌트(Ex. SignupForm, LoginForm 등)에서 useForm을 선언 후 객체로 넘겨주도록 수정했습니다
구조 변경으로 인한 테스트 코드 수정도 file changes에 잡혀있습니다

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

ㅤ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 폼 컴포넌트가 내부적으로 useForm을 호출하지 않고, 외부에서 생성된 methods 객체를 props로 받도록 변경되었습니다.
  * 테스트 코드에서 폼 초기화 및 전달 방식이 methods 기반으로 통일되고, 중복 로직이 재사용 가능한 컴포넌트로 분리되었습니다.

* **Tests**
  * 테스트 폼과 입력 컴포넌트 테스트가 새로운 폼 초기화 방식에 맞게 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->