### PR TITLE
feat: [#59] 회원가입 기능 구현

### DIFF
--- a/src/features/auth/signup/api/signup.API.ts
+++ b/src/features/auth/signup/api/signup.API.ts
@@ -1,0 +1,9 @@
+import axiosInstance from '@/shared/api/axios-instance'
+
+import type { SignupInputData, SignupResponse } from '../model/signup.type'
+
+export async function postSignup(data: SignupInputData): Promise<SignupResponse> {
+  const res = await axiosInstance.post('/auth/signup', data)
+
+  return res.data
+}

--- a/src/features/auth/signup/model/signup.schema.ts
+++ b/src/features/auth/signup/model/signup.schema.ts
@@ -1,0 +1,18 @@
+import z from 'zod'
+
+export const BaseSignupSchema = z.object({
+  email: z.string().email({ message: '이메일 형식으로 입력해주세요' }),
+  name: z.string({ message: '이름을 입력해주세요' }),
+  password: z.string().min(8, { message: '비밀번호를 입력해주세요' }),
+  passwordConfirm: z.string(),
+})
+
+export const SignupSchema = BaseSignupSchema.superRefine(({ password, passwordConfirm }, ctx) => {
+  if (password !== passwordConfirm) {
+    ctx.addIssue({
+      code: 'custom',
+      message: '비밀번호가 일치하지 않습니다',
+      path: ['passwordConfirm'],
+    })
+  }
+})

--- a/src/features/auth/signup/model/signup.type.ts
+++ b/src/features/auth/signup/model/signup.type.ts
@@ -1,0 +1,12 @@
+import z from 'zod'
+
+import type { SignupSchema } from './signup.schema'
+
+// NOTE 타입 어디 위치?
+export type SignupFormDataType = z.infer<typeof SignupSchema>
+export type SignupInputData = Omit<SignupFormDataType, 'passwordConfirm'>
+
+export interface SignupResponse {
+  email: string
+  name: string
+}

--- a/src/features/auth/signup/ui/signup-form.tsx
+++ b/src/features/auth/signup/ui/signup-form.tsx
@@ -26,9 +26,8 @@ export default function SignupForm() {
   } = methods
 
   const handleSubmit = (data: SignupFormDataType) => {
-    // eslint-disable-next-line unused-imports/no-unused-vars
-    const { passwordConfirm, ...restData } = data // 회원가입 API 요청 데이터에는 비밀번호 확인 없음
-    signupMutation.mutate(restData)
+    const { email, name, password } = data // 회원가입 API 요청 데이터에는 비밀번호 확인 없음
+    signupMutation.mutateAsync({ email, name, password })
   }
 
   return (

--- a/src/features/auth/signup/ui/signup-form.tsx
+++ b/src/features/auth/signup/ui/signup-form.tsx
@@ -6,7 +6,6 @@ import Button from '@/shared/ui/button/button.tsx'
 import { Form, FormField, FormLabel } from '@/shared/ui/form'
 import FormFieldWrapper from '@/shared/ui/form/form-field-wrapper'
 import { Input, PasswordInput } from '@/shared/ui/input'
-import Text from '@/shared/ui/text/text'
 
 import { postSignup } from '../api/signup.API'
 import { SignupSchema } from '../model/signup.schema'
@@ -49,18 +48,6 @@ export default function SignupForm() {
       <Button type="submit" intent="solid" disabled={!methods.formState.isValid} className="w-full">
         회원가입
       </Button>
-      <Text typography="b2-normal" className="text-gray-80 flex gap-1 items-center justify-center mt-6">
-        <span>이미 회원이신가요?</span>
-
-        {/* TODO 컴포넌트화
-          NOTE 모달 어떻게 열지 */}
-        <Text
-          typography="b2-heading"
-          className="text-primary-80 underline decoration-solid decoration-2 decoration-skip-ink underline-offset-4"
-        >
-          로그인
-        </Text>
-      </Text>
     </Form>
   )
 }

--- a/src/features/auth/signup/ui/signup-form.tsx
+++ b/src/features/auth/signup/ui/signup-form.tsx
@@ -1,0 +1,71 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+
+import { useCustomMutation } from '@/shared/hooks/use-custom-mutation'
+import Button from '@/shared/ui/button/button.tsx'
+import { Form, FormField, FormLabel } from '@/shared/ui/form'
+import FormFieldWrapper from '@/shared/ui/form/form-field-wrapper'
+import { Input, PasswordInput } from '@/shared/ui/input'
+import Text from '@/shared/ui/text/text'
+
+import { postSignup } from '../api/signup.API'
+import { SignupSchema } from '../model/signup.schema'
+
+import type { SignupFormDataType, SignupInputData } from '../model/signup.type'
+
+export default function SignupForm() {
+  const signupMutation = useCustomMutation((data: SignupInputData) => postSignup(data))
+
+  const methods = useForm<SignupFormDataType>({
+    resolver: zodResolver(SignupSchema),
+    mode: 'onChange', // NOTE onChange로 할지 onSubmit으로 할지
+  })
+
+  const {
+    formState: { isSubmitting, isValid },
+  } = methods
+
+  const handleSubmit = (data: SignupFormDataType) => {
+    // eslint-disable-next-line unused-imports/no-unused-vars
+    const { passwordConfirm, ...restData } = data // 회원가입 API 요청 데이터에는 비밀번호 확인 없음
+    signupMutation.mutate(restData)
+  }
+
+  return (
+    <Form methods={methods} onSubmit={handleSubmit}>
+      <FormFieldWrapper>
+        <FormField name="email">
+          <FormLabel>이메일</FormLabel>
+          <Input placeholder="이메일을 입력해주세요" />
+        </FormField>
+        <FormField name="name">
+          <FormLabel>닉네임</FormLabel>
+          <Input placeholder="이름을 입력해주세요" />
+        </FormField>
+        <FormField name="password">
+          <FormLabel>비밀번호</FormLabel>
+          <PasswordInput mode="password" />
+        </FormField>
+        <FormField name="passwordConfirm">
+          <FormLabel>비밀번호 확인</FormLabel>
+          <PasswordInput mode="confirm" />
+        </FormField>
+      </FormFieldWrapper>
+      <Button type="submit" intent="solid" disabled={!isValid || isSubmitting} className="w-full">
+        회원가입
+      </Button>
+      <Text typography="b2-normal" className="text-gray-80 flex gap-1 items-center justify-center mt-6">
+        <span>이미 회원이신가요?</span>
+
+        {/* TODO 컴포넌트화
+          NOTE 모달 어떻게 열지 */}
+        <Text
+          typography="b2-heading"
+          className="text-primary-80 underline decoration-solid decoration-2 decoration-skip-ink underline-offset-4"
+        >
+          로그인
+        </Text>
+      </Text>
+    </Form>
+  )
+}

--- a/src/features/auth/signup/ui/signup-form.tsx
+++ b/src/features/auth/signup/ui/signup-form.tsx
@@ -21,10 +21,6 @@ export default function SignupForm() {
     mode: 'onChange', // NOTE onChange로 할지 onSubmit으로 할지
   })
 
-  const {
-    formState: { isSubmitting, isValid },
-  } = methods
-
   const handleSubmit = (data: SignupFormDataType) => {
     const { email, name, password } = data // 회원가입 API 요청 데이터에는 비밀번호 확인 없음
     signupMutation.mutateAsync({ email, name, password })
@@ -50,7 +46,7 @@ export default function SignupForm() {
           <PasswordInput mode="confirm" />
         </FormField>
       </FormFieldWrapper>
-      <Button type="submit" intent="solid" disabled={!isValid || isSubmitting} className="w-full">
+      <Button type="submit" intent="solid" disabled={!methods.formState.isValid} className="w-full">
         회원가입
       </Button>
       <Text typography="b2-normal" className="text-gray-80 flex gap-1 items-center justify-center mt-6">

--- a/src/features/auth/signup/ui/signup-modal.tsx
+++ b/src/features/auth/signup/ui/signup-modal.tsx
@@ -7,16 +7,16 @@ import SignupForm from './signup-form'
 
 interface Props {
   isSignupOpen: boolean
-  setIsSignupOepn: Dispatch<SetStateAction<boolean>>
+  setIsSignupOpen: Dispatch<SetStateAction<boolean>>
   trigger: ReactNode
 }
 
-export default function SignupModal({ isSignupOpen, setIsSignupOepn, trigger }: Props) {
+export default function SignupModal({ isSignupOpen, setIsSignupOpen, trigger }: Props) {
   // eslint-disable-next-line unused-imports/no-unused-vars
-  const [isSigninOpen, setIsSigninOepn] = useState<boolean>(false)
+  const [isSigninOpen, setIsSigninOpen] = useState<boolean>(false)
 
   return (
-    <Modal open={isSignupOpen} onOpenChange={setIsSignupOepn}>
+    <Modal open={isSignupOpen} onOpenChange={setIsSignupOpen}>
       <ModalTrigger>{trigger}</ModalTrigger>
       <ModalPortal>
         <ModalOverlay />

--- a/src/features/auth/signup/ui/signup-modal.tsx
+++ b/src/features/auth/signup/ui/signup-modal.tsx
@@ -1,0 +1,26 @@
+import { ModalContent, ModalOverlay, ModalPortal, ModalRoot, ModalTitle, ModalTrigger } from '@/shared/ui/modal'
+
+import SignupForm from './signup-form'
+
+import type { Dispatch, ReactNode, SetStateAction } from 'react'
+
+interface Props {
+  isOpen: boolean
+  setIsOpen: Dispatch<SetStateAction<boolean>>
+  trigger: ReactNode
+}
+
+export default function SignupModal({ isOpen, setIsOpen, trigger }: Props) {
+  return (
+    <ModalRoot defaultOpen={isOpen} onOpenChange={setIsOpen}>
+      <ModalTrigger>{trigger}</ModalTrigger>
+      <ModalPortal>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalTitle className="text-center">회원가입</ModalTitle>
+          <SignupForm />
+        </ModalContent>
+      </ModalPortal>
+    </ModalRoot>
+  )
+}

--- a/src/features/auth/signup/ui/signup-modal.tsx
+++ b/src/features/auth/signup/ui/signup-modal.tsx
@@ -1,18 +1,22 @@
-import { ModalContent, ModalOverlay, ModalPortal, ModalRoot, ModalTitle, ModalTrigger } from '@/shared/ui/modal'
+import { useState, type Dispatch, type ReactNode, type SetStateAction } from 'react'
+
+import { ModalContent, ModalOverlay, ModalPortal, Modal, ModalTitle, ModalTrigger } from '@/shared/ui/modal'
+import Text from '@/shared/ui/text/text'
 
 import SignupForm from './signup-form'
 
-import type { Dispatch, ReactNode, SetStateAction } from 'react'
-
 interface Props {
-  isOpen: boolean
-  setIsOpen: Dispatch<SetStateAction<boolean>>
+  isSignupOpen: boolean
+  setIsSignupOepn: Dispatch<SetStateAction<boolean>>
   trigger: ReactNode
 }
 
-export default function SignupModal({ isOpen, setIsOpen, trigger }: Props) {
+export default function SignupModal({ isSignupOpen, setIsSignupOepn, trigger }: Props) {
+  // eslint-disable-next-line unused-imports/no-unused-vars
+  const [isSigninOpen, setIsSigninOepn] = useState<boolean>(false)
+
   return (
-    <ModalRoot defaultOpen={isOpen} onOpenChange={setIsOpen}>
+    <Modal open={isSignupOpen} onOpenChange={setIsSignupOepn}>
       <ModalTrigger>{trigger}</ModalTrigger>
       <ModalPortal>
         <ModalOverlay />
@@ -20,7 +24,19 @@ export default function SignupModal({ isOpen, setIsOpen, trigger }: Props) {
           <ModalTitle className="text-center">회원가입</ModalTitle>
           <SignupForm />
         </ModalContent>
+        <Text typography="b2-normal" className="text-gray-80 flex gap-1 items-center justify-center mt-6">
+          <span>이미 회원이신가요?</span>
+
+          {/* TODO 컴포넌트화
+          NOTE 모달 어떻게 열지 */}
+          <Text
+            typography="b2-heading"
+            className="text-primary-80 underline decoration-solid decoration-2 decoration-skip-ink underline-offset-4"
+          >
+            로그인
+          </Text>
+        </Text>
       </ModalPortal>
-    </ModalRoot>
+    </Modal>
   )
 }

--- a/src/features/auth/test/test-button.tsx
+++ b/src/features/auth/test/test-button.tsx
@@ -1,0 +1,12 @@
+import Button from '@/shared/ui/button/button.tsx'
+
+import useTestMutation from './use-test-mutation'
+
+export default function TestButton() {
+  const testMutation = useTestMutation()
+  const handleClick = () => {
+    testMutation.mutate()
+  }
+
+  return <Button onClick={handleClick}>test button</Button>
+}

--- a/src/features/auth/test/test.API.ts
+++ b/src/features/auth/test/test.API.ts
@@ -1,0 +1,5 @@
+import axiosInstance from '@/shared/api/axios-instance'
+
+export async function postTest(): Promise<void> {
+  await axiosInstance.post('/auth/test')
+}

--- a/src/features/auth/test/use-test-mutation.ts
+++ b/src/features/auth/test/use-test-mutation.ts
@@ -1,0 +1,11 @@
+import { useMutation } from '@tanstack/react-query'
+
+import { postTest } from './test.API'
+
+function useTestMutation() {
+  return useMutation({
+    mutationFn: () => postTest(),
+  })
+}
+
+export default useTestMutation


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

- close #59

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

회원가입 폼 및 모달 구현

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

<img width="356" height="599" alt="image" src="https://github.com/user-attachments/assets/74036457-03ab-4a61-ad61-b25a4319d993" />


## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

로그인, 회원가입이 현재 둘다 모달로 되어있어서 로그인에서 회원가입을 클릭하면 로그인 모달이 꺼지고 회원가입 모달이 켜져야하는데
그게 제가 했을땐 되지가 않고 두개가 open 되어서 모달을 저렇게 구현하면 안되는건지 코멘트 부탁드립니다
(모달이 모달에서만 상태가 관리되는게 아니라 전역으로 관리되어야 할 것 같다고 생각이 드네요..)

swagger상으로 test 엔드포인트가 있어서 제가 테스트용으로 사용했던건데
테스트용으로 있으면 인가됐는지 확인하기 좋지않을까 해서 올려봤습니다
필요없다면 삭제후 force push 하겠습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **신규 기능**
  * 회원가입 폼 및 모달이 추가되어 이메일, 이름, 비밀번호 입력 및 검증이 가능합니다.
  * 회원가입 시 비밀번호와 비밀번호 확인이 일치하는지 자동으로 검증됩니다.
  * 회원가입 요청 및 응답 처리가 지원됩니다.
  * 테스트용 버튼과 API가 추가되어 기능 검증이 가능합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->