### PR TITLE
refactor: [#113] 모달 리팩토링 

### DIFF
--- a/src/shared/ui/modal/README.md
+++ b/src/shared/ui/modal/README.md
@@ -13,20 +13,21 @@
 
 ## Components
 
-### ModalRoot
+### Modal
 
 모달의 루트 컴포넌트로, 상태 관리와 컨텍스트를 제공합니다.
 
 ```tsx
-import { ModalRoot } from '@/shared/ui/modal'
+import { Modal } from '@/shared/ui/modal'
 
-<ModalRoot defaultOpen={false} onOpenChange={(open) => console.log(open)}>
+<Modal defaultOpen={false} onOpenChange={(open) => console.log(open)}>
   {/* 모달 컴포넌트들 */}
-</ModalRoot>
+</Modal>
 ```
 
 **Props:**
 
+- `open?: boolean` - 모달의 열림 상태 (외부 상태 주입)
 - `defaultOpen?: boolean` - 초기 열림 상태
 - `onOpenChange?: (open: boolean) => void` - 상태 변경 콜백
 - `children: ReactNode` - 모달 컴포넌트들
@@ -147,7 +148,7 @@ import { ModalCloseButton } from '@/shared/ui/modal'
 
 ```tsx
 import {
-  ModalRoot,
+  Modal,
   ModalTrigger,
   ModalPortal,
   ModalOverlay,
@@ -159,7 +160,7 @@ import {
 
 function BasicModal() {
   return (
-    <ModalRoot>
+    <Modal>
       <ModalTrigger>Open Modal</ModalTrigger>
       <ModalPortal>
         <ModalOverlay />
@@ -169,7 +170,7 @@ function BasicModal() {
           <ModalCloseButton />
         </ModalContent>
       </ModalPortal>
-    </ModalRoot>
+    </Modal>
   )
 }
 ```
@@ -183,7 +184,7 @@ function ControlledModal() {
   const [isOpen, setIsOpen] = useState(false)
 
   return (
-    <ModalRoot defaultOpen={isOpen} onOpenChange={setIsOpen}>
+    <Modal defaultOpen={isOpen} onOpenChange={setIsOpen}>
       <ModalTrigger>Open Modal</ModalTrigger>
       <ModalPortal>
         <ModalOverlay />
@@ -193,7 +194,7 @@ function ControlledModal() {
           <ModalCloseButton />
         </ModalContent>
       </ModalPortal>
-    </ModalRoot>
+    </Modal>
   )
 }
 ```
@@ -203,7 +204,7 @@ function ControlledModal() {
 ```tsx
 function CustomTriggerModal() {
   return (
-    <ModalRoot>
+    <Modal>
       <ModalTrigger asChild>
         <button className="px-4 py-2 bg-blue-500 text-white rounded">커스텀 버튼</button>
       </ModalTrigger>
@@ -215,7 +216,7 @@ function CustomTriggerModal() {
           <ModalCloseButton />
         </ModalContent>
       </ModalPortal>
-    </ModalRoot>
+    </Modal>
   )
 }
 ```

--- a/src/shared/ui/modal/index.ts
+++ b/src/shared/ui/modal/index.ts
@@ -1,4 +1,4 @@
-export { default as ModalRoot } from './modal-root'
+export { default as Modal } from './modal'
 export { default as ModalTrigger } from './modal-trigger'
 export { default as ModalPortal } from './modal-portal'
 export { default as ModalOverlay } from './modal-overlay'

--- a/src/shared/ui/modal/modal.test.tsx
+++ b/src/shared/ui/modal/modal.test.tsx
@@ -14,9 +14,9 @@ import {
   ModalCloseButton,
 } from './index'
 
-function ModalComponent(isOpen?: boolean, onOpenChange?: (open: boolean) => void) {
+function ModalTest(open?: boolean, onOpenChange?: (open: boolean) => void) {
   return (
-    <Modal open={isOpen} onOpenChange={onOpenChange}>
+    <Modal open={open} onOpenChange={onOpenChange}>
       <ModalTrigger>Open Modal</ModalTrigger>
       <ModalPortal>
         <ModalOverlay />
@@ -51,13 +51,13 @@ async function testModalOpenAndClose(ModalComponent: ComponentType) {
   expect(screen.queryByText('Description')).not.toBeInTheDocument()
 }
 
-function DefaultModal({ isOpen, onOpenChange }: { isOpen?: boolean; onOpenChange?: (open: boolean) => void }) {
-  return ModalComponent(isOpen, onOpenChange)
+function DefaultModal({ open, onOpenChange }: { open?: boolean; onOpenChange?: (open: boolean) => void }) {
+  return ModalTest(open, onOpenChange)
 }
 
 function ExternalStateModal() {
   const [isOpen, setIsOpen] = useState(false)
-  return ModalComponent(isOpen, setIsOpen)
+  return ModalTest(isOpen, setIsOpen)
 }
 
 describe('ModalRoot', () => {

--- a/src/shared/ui/modal/modal.test.tsx
+++ b/src/shared/ui/modal/modal.test.tsx
@@ -4,7 +4,7 @@ import { useState, type ComponentType } from 'react'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import {
-  ModalRoot,
+  Modal,
   ModalTrigger,
   ModalPortal,
   ModalOverlay,
@@ -14,9 +14,9 @@ import {
   ModalCloseButton,
 } from './index'
 
-function Modal(isOpen?: boolean, onOpenChange?: (open: boolean) => void) {
+function ModalComponent(isOpen?: boolean, onOpenChange?: (open: boolean) => void) {
   return (
-    <ModalRoot defaultOpen={isOpen} onOpenChange={onOpenChange}>
+    <Modal open={isOpen} onOpenChange={onOpenChange}>
       <ModalTrigger>Open Modal</ModalTrigger>
       <ModalPortal>
         <ModalOverlay />
@@ -26,7 +26,7 @@ function Modal(isOpen?: boolean, onOpenChange?: (open: boolean) => void) {
           <ModalCloseButton />
         </ModalContent>
       </ModalPortal>
-    </ModalRoot>
+    </Modal>
   )
 }
 
@@ -52,12 +52,12 @@ async function testModalOpenAndClose(ModalComponent: ComponentType) {
 }
 
 function DefaultModal({ isOpen, onOpenChange }: { isOpen?: boolean; onOpenChange?: (open: boolean) => void }) {
-  return Modal(isOpen, onOpenChange)
+  return ModalComponent(isOpen, onOpenChange)
 }
 
 function ExternalStateModal() {
   const [isOpen, setIsOpen] = useState(false)
-  return Modal(isOpen, setIsOpen)
+  return ModalComponent(isOpen, setIsOpen)
 }
 
 describe('ModalRoot', () => {

--- a/src/shared/ui/modal/modal.tsx
+++ b/src/shared/ui/modal/modal.tsx
@@ -5,6 +5,8 @@ import { useEscapeKeydown, useControllableState } from '@/shared/hooks'
 import { ModalProvider } from './modal-context'
 
 interface Props {
+  /** 모달의 열림 상태 (외부 상태 주입) */
+  open?: boolean
   /** 모달의 초기 열림 상태 */
   defaultOpen?: boolean
   /** 모달 상태 변경 시 호출되는 콜백 함수 */
@@ -21,7 +23,7 @@ interface Props {
  *
  * @example
  * ```tsx
- * <ModalRoot defaultOpen={false} onOpenChange={setIsOpen}>
+ * <Modal open={isOpen} defaultOpen={false} onOpenChange={setIsOpen}>
  *   <ModalTrigger>Open Modal</ModalTrigger>
  *   <ModalPortal>
  *     <ModalOverlay />
@@ -31,19 +33,20 @@ interface Props {
  *       <ModalCloseButton />
  *     </ModalContent>
  *   </ModalPortal>
- * </ModalRoot>
+ * </Modal>
  * ```
  *
  * @param props - ModalRoot 컴포넌트의 props
+ * @param props.open - 모달의 열림 상태
  * @param props.defaultOpen - 모달의 초기 열림 상태 (기본값: false)
  * @param props.onOpenChange - 모달 상태 변경 시 호출되는 콜백 함수
  * @param props.children - 모달 내부에 렌더링될 자식 컴포넌트들
  *
  * @returns 모달 컨텍스트를 제공하는 Provider 컴포넌트
  */
-export default function ModalRoot({ children, defaultOpen, onOpenChange }: Props) {
+export default function Modal({ children, open, defaultOpen, onOpenChange }: Props) {
   const [isOpen, setOpen] = useControllableState({
-    prop: defaultOpen,
+    prop: open,
     defaultProp: defaultOpen || false,
     onChange: onOpenChange,
   })


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호
- closed #113 
ㅤ

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

모달 네이밍 변경 및 Props 추가

- [x] ModalRoot -> Modal 네이밍 변경
- [x] Modal 외부 상태 주입받을 수 있도록 props 추가

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

ㅤ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 모달 컴포넌트에 외부에서 열림 상태를 제어할 수 있는 `open` 속성이 추가되었습니다.

* **Documentation**
  * 모달 컴포넌트의 이름이 `ModalRoot`에서 `Modal`로 변경되었으며, 문서와 예제 코드가 이에 맞게 업데이트되었습니다.
  * 불필요한 `open` 속성 설명이 문서에서 제거되었습니다.

* **Tests**
  * 테스트 코드가 새로운 컴포넌트 이름과 속성(`open`)에 맞게 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->