### PR TITLE
refactor: [#136] auth 모달

### DIFF
--- a/src/features/auth/signin/model/auth-modal.type.ts
+++ b/src/features/auth/signin/model/auth-modal.type.ts
@@ -1,0 +1,1 @@
+export type AuthModalType = 'LoginSelect' | 'EmailLogin' | 'Signup' | null

--- a/src/features/auth/signin/ui/email-signin-modal.tsx
+++ b/src/features/auth/signin/ui/email-signin-modal.tsx
@@ -1,20 +1,19 @@
-import { ModalContent, ModalOverlay, ModalPortal, Modal, ModalTitle, ModalTrigger } from '@/shared/ui/modal'
+import { ModalContent, ModalOverlay, ModalPortal, Modal, ModalTitle } from '@/shared/ui/modal'
 import Text from '@/shared/ui/text/text'
 
 import SigninForm from './signin-form'
 
-import type { Dispatch, ReactNode, SetStateAction } from 'react'
+import type { AuthModalType } from '../model/auth-modal.type'
 
 interface Props {
   isOpen: boolean
-  setIsOpen: Dispatch<SetStateAction<boolean>>
-  trigger: ReactNode
+  setSwitchModal: (open: AuthModalType) => void
+  setClose: (open: boolean) => void
 }
 
-export default function EmailSigninModal({ isOpen, setIsOpen, trigger }: Props) {
+export default function EmailSigninModal({ isOpen, setSwitchModal, setClose }: Props) {
   return (
-    <Modal open={isOpen} onOpenChange={setIsOpen}>
-      <ModalTrigger>{trigger}</ModalTrigger>
+    <Modal open={isOpen} onOpenChange={setClose}>
       <ModalPortal>
         <ModalOverlay />
         <ModalContent>
@@ -25,7 +24,9 @@ export default function EmailSigninModal({ isOpen, setIsOpen, trigger }: Props) 
           <Text typography="b2-normal" className="text-gray-80 flex gap-1 items-center justify-center mt-6">
             <span>캘픽이 처음이신가요?</span>
             <Text
+              as="button"
               typography="b2-heading"
+              onClick={() => setSwitchModal('Signup')}
               className="text-primary-80 underline decoration-solid decoration-2 decoration-skip-ink underline-offset-4"
             >
               회원가입

--- a/src/features/auth/signin/ui/login-select-button.tsx
+++ b/src/features/auth/signin/ui/login-select-button.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react'
+
+import Text from '@/shared/ui/text/text'
+import { cn } from '@/shared/utils'
+
+import SignupModal from '../../signup/ui/signup-modal'
+
+import EmailSigninModal from './email-signin-modal'
+import LoginSelectModal from './login-select-modal'
+
+import type { AuthModalType } from '../model/auth-modal.type'
+
+export default function LoginSelectButton({ className }: { className?: string }) {
+  const [modalType, setModalType] = useState<AuthModalType>(null)
+
+  const handleModalChange = (open: boolean) => {
+    if (!open) {
+      setModalType(null)
+    }
+  }
+  return (
+    <>
+      <Text
+        as="button"
+        typography="label"
+        className={cn('text-gray-80', className)}
+        onClick={() => setModalType('LoginSelect')}
+      >
+        로그인
+      </Text>
+      {modalType === 'LoginSelect' && (
+        <LoginSelectModal
+          isOpen={modalType === 'LoginSelect'}
+          setSwitchModal={setModalType}
+          setClose={handleModalChange}
+        />
+      )}
+      {modalType === 'EmailLogin' && (
+        <EmailSigninModal
+          isOpen={modalType === 'EmailLogin'}
+          setSwitchModal={setModalType}
+          setClose={handleModalChange}
+        />
+      )}
+      {modalType === 'Signup' && (
+        <SignupModal isSignupOpen={modalType === 'Signup'} setSwitchModal={setModalType} setClose={handleModalChange} />
+      )}
+    </>
+  )
+}

--- a/src/features/auth/signin/ui/login-select-modal.tsx
+++ b/src/features/auth/signin/ui/login-select-modal.tsx
@@ -1,24 +1,18 @@
-import { useState, type Dispatch, type ReactNode, type SetStateAction } from 'react'
-
 import { IconKakaoLogo } from '@/shared/assets/icons'
-import { ModalContent, ModalOverlay, ModalPortal, Modal, ModalTitle, ModalTrigger } from '@/shared/ui/modal'
+import { ModalContent, ModalOverlay, ModalPortal, Modal, ModalTitle } from '@/shared/ui/modal'
 import Text from '@/shared/ui/text/text'
 
-import EmailSigninModal from './email-signin-modal'
+import type { AuthModalType } from '../model/auth-modal.type'
 
 interface Props {
   isOpen: boolean
-  setIsOpen: Dispatch<SetStateAction<boolean>>
-  trigger: ReactNode
+  setSwitchModal: (open: AuthModalType) => void
+  setClose: (open: boolean) => void
 }
 
-export default function LoginSelectModal({ isOpen, setIsOpen, trigger }: Props) {
-  const [isEmailModalOpen, setIsEmailModalOpen] = useState<boolean>(false)
-  // NOTE 임시 상태이긴한데 현재 이 모달을 닫고 email 모달을 열려면 이렇게 상태관리를 하는게 맞을까요 ??
-
+export default function LoginSelectModal({ isOpen, setSwitchModal, setClose }: Props) {
   return (
-    <Modal open={isOpen} onOpenChange={setIsOpen}>
-      <ModalTrigger>{trigger}</ModalTrigger>
+    <Modal open={isOpen} onOpenChange={setClose}>
       <ModalPortal>
         <ModalOverlay />
         <ModalContent>
@@ -33,26 +27,23 @@ export default function LoginSelectModal({ isOpen, setIsOpen, trigger }: Props) 
               <IconKakaoLogo />
               카카오로그인
             </Text>
-            <EmailSigninModal
-              isOpen={isEmailModalOpen}
-              setIsOpen={setIsEmailModalOpen}
-              trigger={
-                <Text
-                  as="button"
-                  typography="label"
-                  className="bg-primary-5 font-semibold flex gap-2 items-center justify-center w-full rounded-[0.25rem] py-2.5"
-                >
-                  이메일 로그인
-                </Text>
-              }
-            />
+            <Text
+              as="button"
+              typography="label"
+              onClick={() => setSwitchModal('EmailLogin')}
+              className="bg-primary-5 font-semibold flex gap-2 items-center justify-center w-full rounded-[0.25rem] py-2.5"
+            >
+              이메일 로그인
+            </Text>
           </div>
           {/* TODO 컴포넌트화
                 NOTE 모달 어떻게 열지 */}
           <Text typography="b2-normal" className="text-gray-80 flex gap-1 items-center justify-center mt-6">
             <span>캘픽이 처음이신가요?</span>
             <Text
+              as="button"
               typography="b2-heading"
+              onClick={() => setSwitchModal('Signup')}
               className="text-primary-80 underline decoration-solid decoration-2 decoration-skip-ink underline-offset-4"
             >
               회원가입

--- a/src/features/auth/signup/ui/signup-modal.tsx
+++ b/src/features/auth/signup/ui/signup-modal.tsx
@@ -1,41 +1,40 @@
-import { useState, type Dispatch, type ReactNode, type SetStateAction } from 'react'
-
-import { ModalContent, ModalOverlay, ModalPortal, Modal, ModalTitle, ModalTrigger } from '@/shared/ui/modal'
+import { ModalContent, ModalOverlay, ModalPortal, Modal, ModalTitle } from '@/shared/ui/modal'
 import Text from '@/shared/ui/text/text'
 
 import SignupForm from './signup-form'
 
+import type { AuthModalType } from '../../signin/model/auth-modal.type'
+
 interface Props {
   isSignupOpen: boolean
-  setIsSignupOpen: Dispatch<SetStateAction<boolean>>
-  trigger: ReactNode
+  setSwitchModal: (open: AuthModalType) => void
+  setClose: (open: boolean) => void
 }
 
-export default function SignupModal({ isSignupOpen, setIsSignupOpen, trigger }: Props) {
-  // eslint-disable-next-line unused-imports/no-unused-vars
-  const [isSigninOpen, setIsSigninOpen] = useState<boolean>(false)
-
+export default function SignupModal({ isSignupOpen, setSwitchModal, setClose }: Props) {
   return (
-    <Modal open={isSignupOpen} onOpenChange={setIsSignupOpen}>
-      <ModalTrigger>{trigger}</ModalTrigger>
+    <Modal open={isSignupOpen} onOpenChange={setClose}>
       <ModalPortal>
         <ModalOverlay />
         <ModalContent>
           <ModalTitle className="text-center">회원가입</ModalTitle>
           <SignupForm />
-        </ModalContent>
-        <Text typography="b2-normal" className="text-gray-80 flex gap-1 items-center justify-center mt-6">
-          <span>이미 회원이신가요?</span>
 
-          {/* TODO 컴포넌트화
+          <Text typography="b2-normal" className="text-gray-80 flex gap-1 items-center justify-center mt-6">
+            <span>이미 회원이신가요?</span>
+
+            {/* TODO 컴포넌트화
           NOTE 모달 어떻게 열지 */}
-          <Text
-            typography="b2-heading"
-            className="text-primary-80 underline decoration-solid decoration-2 decoration-skip-ink underline-offset-4"
-          >
-            로그인
+            <Text
+              as="button"
+              typography="b2-heading"
+              onClick={() => setSwitchModal('EmailLogin')}
+              className="text-primary-80 underline decoration-solid decoration-2 decoration-skip-ink underline-offset-4"
+            >
+              로그인
+            </Text>
           </Text>
-        </Text>
+        </ModalContent>
       </ModalPortal>
     </Modal>
   )


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

- close #136

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

로그인 회원가입 모달에서 버튼을 클릭했을때 스위칭 되지 않는 부분을 수정해서 올렸습니다
login-select-button은 GNB에서 쓰일 예정입니다

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

ㅤ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 로그인, 이메일 로그인, 회원가입 모달을 하나의 버튼에서 전환할 수 있도록 통합된 로그인 선택 버튼이 추가되었습니다.

* **리팩터링**
  * 각 인증 모달(로그인, 이메일 로그인, 회원가입)의 열림/닫힘 및 전환 방식이 개선되어, 외부에서 모달 상태를 더 쉽게 제어할 수 있습니다.
  * 모달 트리거 요소가 제거되고, 버튼 클릭을 통한 모달 전환이 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->