### PR TITLE
feat: [#141] 로그인 후 유저 정보를 전역으로 저장하도록 user store 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "react-hook-form": "^7.60.0",
         "react-router": "^7.6.3",
         "tailwind-merge": "^3.3.1",
-        "zod": "^3.25.75"
+        "zod": "^3.25.75",
+        "zustand": "^5.0.6"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",
@@ -10597,6 +10598,34 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.6.tgz",
+      "integrity": "sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "react-hook-form": "^7.60.0",
     "react-router": "^7.6.3",
     "tailwind-merge": "^3.3.1",
-    "zod": "^3.25.75"
+    "zod": "^3.25.75",
+    "zustand": "^5.0.6"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",

--- a/src/entities/user/models/use-user-store.ts
+++ b/src/entities/user/models/use-user-store.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand'
+
+import type { User } from './user.types'
+
+interface UserStoreState {
+  user: User | null
+  setUser: (user: User) => void
+  clearUser: () => void
+}
+
+export const useUserStore = create<UserStoreState>((set) => ({
+  user: null,
+  setUser: (user) => set({ user }),
+  clearUser: () => set({ user: null }),
+}))

--- a/src/entities/user/models/use-user-store.ts
+++ b/src/entities/user/models/use-user-store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 
 import type { User } from './user.types'
 
@@ -8,8 +9,13 @@ interface UserStoreState {
   clearUser: () => void
 }
 
-export const useUserStore = create<UserStoreState>((set) => ({
-  user: null,
-  setUser: (user) => set({ user }),
-  clearUser: () => set({ user: null }),
-}))
+export const useUserStore = create(
+  persist<UserStoreState>(
+    (set) => ({
+      user: null,
+      setUser: (user) => set({ user }),
+      clearUser: () => set({ user: null }),
+    }),
+    { name: 'user' },
+  ),
+)

--- a/src/entities/user/models/user.types.ts
+++ b/src/entities/user/models/user.types.ts
@@ -1,0 +1,6 @@
+export interface User {
+  userId: number
+  email: string
+  name: string
+  profileUrl: string | null
+}

--- a/src/features/auth/logout/model/use-logout-mutation.ts
+++ b/src/features/auth/logout/model/use-logout-mutation.ts
@@ -1,15 +1,20 @@
 import { useMutation } from '@tanstack/react-query'
 
+import { useUserStore } from '@/entities/user/models/use-user-store'
+import { devLog } from '@/shared/utils/dev-log'
+
 import { postLogout } from '../api/logout.API'
 
-function useLogoutMutation() {
+export default function useLogoutMutation() {
+  const clearUser = useUserStore((state) => state.clearUser)
+
   return useMutation({
     mutationFn: () => postLogout(),
-    onSuccess: () => {},
-    onError: (e) => {
-      console.error(e)
+    onSuccess: () => {
+      clearUser()
+    },
+    onError: (error) => {
+      devLog('error', '로그아웃 에러', error.message)
     },
   })
 }
-
-export default useLogoutMutation

--- a/src/features/auth/logout/model/use-logout-mutation.ts
+++ b/src/features/auth/logout/model/use-logout-mutation.ts
@@ -7,11 +7,13 @@ import { postLogout } from '../api/logout.API'
 
 export default function useLogoutMutation() {
   const clearUser = useUserStore((state) => state.clearUser)
+  const clearUserStorage = useUserStore.persist.clearStorage
 
   return useMutation({
     mutationFn: () => postLogout(),
     onSuccess: () => {
       clearUser()
+      clearUserStorage()
     },
     onError: (error) => {
       devLog('error', '로그아웃 에러', error.message)

--- a/src/features/auth/signin/api/signin.API.ts
+++ b/src/features/auth/signin/api/signin.API.ts
@@ -1,12 +1,15 @@
 import axiosInstance from '@/shared/api/axios-instance'
 
 import type { SigninFormDataType } from '../model/signin.type'
+import type { User } from '@/entities/user/models/user.types'
 
-export async function postSignin(data: SigninFormDataType): Promise<void> {
+export async function postSignin(data: SigninFormDataType): Promise<User> {
   const res = await axiosInstance.post('/auth/login', data)
   const token = res.headers.authorization?.split(' ')[1]
 
   if (token) {
     localStorage.setItem('token', token)
   }
+
+  return res.data.data // 유저 정보만 반환
 }

--- a/src/features/auth/signin/model/use-signin-mutation.ts
+++ b/src/features/auth/signin/model/use-signin-mutation.ts
@@ -1,0 +1,24 @@
+import { useMutation } from '@tanstack/react-query'
+
+import { useUserStore } from '@/entities/user/models/use-user-store'
+import { devLog } from '@/shared/utils/dev-log'
+
+import { postSignin } from '../api/signin.API'
+
+import type { SigninFormDataType } from './signin.type'
+
+function useSigninMutation() {
+  const setUser = useUserStore((state) => state.setUser)
+
+  return useMutation({
+    mutationFn: (data: SigninFormDataType) => postSignin(data),
+    onSuccess: (res) => {
+      setUser(res)
+    },
+    onError: (error) => {
+      devLog('error', '로그인 에러', error.message)
+    },
+  })
+}
+
+export default useSigninMutation

--- a/src/features/auth/signin/ui/signin-form.tsx
+++ b/src/features/auth/signin/ui/signin-form.tsx
@@ -1,13 +1,12 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
 
-import { useCustomMutation } from '@/shared/hooks/use-custom-mutation'
 import Button from '@/shared/ui/button/button.tsx'
 import { Form, FormField, FormFieldWrapper, FormLabel } from '@/shared/ui/form'
 import { Input, PasswordInput } from '@/shared/ui/input'
 
-import { postSignin } from '../api/signin.API'
 import { SigninSchema } from '../model/signin.schema'
+import useSigninMutation from '../model/use-signin-mutation'
 
 import type { SigninFormDataType } from '../model/signin.type'
 
@@ -21,7 +20,7 @@ export default function SigninForm() {
     formState: { isValid, isSubmitting },
   } = methods
 
-  const signinMutation = useCustomMutation((data: SigninFormDataType) => postSignin(data))
+  const signinMutation = useSigninMutation()
 
   const handleSubmit = (data: SigninFormDataType) => {
     signinMutation.mutate(data)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

- close #141

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### AS-IS
로그인 요청 성공 시 accessToken은 쿠키로 저장되지만 응답으로 받은 사용자 정보(user)는 아무 곳에도 저장되지 않음
페이지 이동 후 유저 정보 활용이 불가능하며, 상태 공유가 되지 않음

### To-Be
로그인 성공 시 응답으로 받은 user 정보를 Zustand 전역 상태에 저장
다른 컴포넌트에서 useUserStore를 통해 user 정보 접근 가능하도록 처리
로그인 이후 사용자 정보를 헤더/프로필 등에서 즉시 활용할 수 있도록 개선
zustand에서 새로 고침하면, 유저 정보가 초기화되는 것을 방지하기 위해 persist 메소드를 통해 새로고침하더라도 유저 정보 유지

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

customMutation은 다른 분들 사용안하실것 같아서 다시 useSigninMutation으로 분리했습니다~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 상태를 관리하고 세션 간에 유지하는 사용자 저장소가 추가되었습니다.
  * 사용자 정보를 정의하는 User 타입이 도입되었습니다.
  * 로그인 시 사용자 정보를 받아와 상태를 갱신하는 기능이 추가되었습니다.

* **버그 수정**
  * 로그아웃 시 사용자 상태와 저장소가 올바르게 초기화되도록 개선되었습니다.

* **리팩터**
  * 로그인 및 로그아웃 관련 훅이 전용 커스텀 훅으로 분리되어 코드 구조가 간결해졌습니다.

* **기타**
  * 새로운 상태 관리 라이브러리(zustand)가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->