### PR TITLE
feat: [#164] 로그인 여부에 따라 redirect하는 PrivateRouter 구현

### DIFF
--- a/src/pages/private-route.tsx
+++ b/src/pages/private-route.tsx
@@ -1,0 +1,7 @@
+import { Navigate, Outlet } from 'react-router'
+
+import useAuthenticate from '@/shared/hooks/use-authenticate'
+
+export default function PrivateRoute() {
+  return useAuthenticate() ? <Outlet /> : <Navigate to="/" />
+}

--- a/src/pages/private-route.tsx
+++ b/src/pages/private-route.tsx
@@ -1,7 +1,9 @@
 import { Navigate, Outlet } from 'react-router'
 
-import useAuthenticate from '@/shared/hooks/use-authenticate'
+import { useUserStore } from '@/entities/user/models/use-user-store'
 
 export default function PrivateRoute() {
-  return useAuthenticate() ? <Outlet /> : <Navigate to="/" />
+  const user = useUserStore((state) => !!state.user)
+
+  return user ? <Outlet /> : <Navigate to="/" />
 }

--- a/src/shared/hooks/use-authenticate.ts
+++ b/src/shared/hooks/use-authenticate.ts
@@ -1,0 +1,8 @@
+import { useUserStore } from '@/entities/user/models/use-user-store'
+
+export default function useAuthenticate() {
+  const { user } = useUserStore()
+  // NOTE 이 부분 리뷰 부탁드립니다
+
+  return !!user
+}

--- a/src/shared/hooks/use-authenticate.ts
+++ b/src/shared/hooks/use-authenticate.ts
@@ -1,8 +1,0 @@
-import { useUserStore } from '@/entities/user/models/use-user-store'
-
-export default function useAuthenticate() {
-  const { user } = useUserStore()
-  // NOTE 이 부분 리뷰 부탁드립니다
-
-  return !!user
-}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

- close #164

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### AS-IS
현재는 로그인 여부에 따른 리다이렉트 처리가 되어 있지 않습니다
처리되어 있더라도, 각 페이지 컴포넌트 내부에서 useEffect를 사용해 리다이렉트를 수행하고 있어
페이지가 잠깐 보여졌다가 리다이렉트되는 현상이 발생할 수 있습니다

### TO-BE
이번 작업에서 페이지 렌더링 전에 인증 상태를 검사하고 인증되지 않은 경우 즉시 리다이렉트하도록 개선했습니다
불필요한 페이지 노출 없이 즉각적으로 접근을 제어합니다

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항
> 팀원들이 참고해야할 부분이 있다면 적어주세요

이 컴포넌트는 사용하더라도 일요일이나 월요일에 최종적으로 어느정도 마무리되고 라우터에 처리해주면 될 것 같습니다

~~현재 인증되었는지 판단하기 위해 useUserStore에서 user를 가져와 true/false가 반환이 되게끔 했습니다~~
~~근데 useUserStore는 Entities에 위치한 훅이기 때문에 사실 shared에서 참조하면 안되는 훅이라서..~~
~~고민을 조금 해봤는데 어떻게 하는게 좋을지 모르겠어서 일단 의견을 듣고자 entities에서 import한 상태로 pr을 올려봤습니다~~

~~`use-authenticate.ts` 그냥 이 파일을 똑같이 entities에 올리는게 차라리 나을까요 ??~~
~~쓰면서 생각해보니 괜히 shared에 위치시킨건가 하는생각도 드네요~~

=> `use-authenticate.ts` 파일 삭제하고 PrivateRouter 파일에서 바로 useUserStore import해서 사용했습니다~~!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 인증된 사용자만 접근할 수 있는 프라이빗 라우트 기능이 추가되었습니다. 인증되지 않은 사용자는 자동으로 메인 페이지로 리디렉션됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->