### PR TITLE
feat: [#166] 로그인 성공 시 모달 닫기 및 회원가입 후 로그인 모달 전환 기능 구현

### DIFF
--- a/src/features/auth/signin/ui/email-signin-modal.tsx
+++ b/src/features/auth/signin/ui/email-signin-modal.tsx
@@ -18,7 +18,7 @@ export default function EmailSigninModal({ isOpen, setSwitchModal, setClose }: P
         <ModalOverlay />
         <ModalContent>
           <ModalTitle className="text-center">로그인</ModalTitle>
-          <SigninForm />
+          <SigninForm onSigninSuccess={() => setSwitchModal(null)} />
           {/* TODO 컴포넌트화
             NOTE 모달 어떻게 열지 */}
           <Text typography="b2-normal" className="text-gray-80 flex gap-1 items-center justify-center mt-6">

--- a/src/features/auth/signin/ui/login-select-modal.tsx
+++ b/src/features/auth/signin/ui/login-select-modal.tsx
@@ -1,4 +1,3 @@
-import { IconKakaoLogo } from '@/shared/assets/icons'
 import { ModalContent, ModalOverlay, ModalPortal, Modal, ModalTitle } from '@/shared/ui/modal'
 import Text from '@/shared/ui/text/text'
 
@@ -19,14 +18,14 @@ export default function LoginSelectModal({ isOpen, setSwitchModal, setClose }: P
           <ModalTitle className="text-center">캘픽 로그인</ModalTitle>
           <div className="flex flex-col gap-3 mt-8 mb-6">
             {/* TODO 카카오 로그인 onClick 추가 */}
-            <Text
+            {/* <Text
               as="button"
               typography="label"
               className="bg-[#FEE500] font-semibold flex gap-2 items-center justify-center w-full rounded-[0.25rem] py-2.5"
             >
               <IconKakaoLogo />
               카카오로그인
-            </Text>
+            </Text> */}
             <Text
               as="button"
               typography="label"

--- a/src/features/auth/signin/ui/signin-form.tsx
+++ b/src/features/auth/signin/ui/signin-form.tsx
@@ -10,7 +10,7 @@ import useSigninMutation from '../model/use-signin-mutation'
 
 import type { SigninFormDataType } from '../model/signin.type'
 
-export default function SigninForm() {
+export default function SigninForm({ onSigninSuccess }: { onSigninSuccess?: () => void }) {
   const methods = useForm<SigninFormDataType>({
     resolver: zodResolver(SigninSchema),
     mode: 'onChange', // NOTE: 'onChange' 과 'onSubmit'중에 어떤게 나을지
@@ -24,6 +24,9 @@ export default function SigninForm() {
 
   const handleSubmit = (data: SigninFormDataType) => {
     signinMutation.mutate(data)
+    if (onSigninSuccess) {
+      onSigninSuccess()
+    }
   }
 
   return (

--- a/src/features/auth/signin/ui/signin-form.tsx
+++ b/src/features/auth/signin/ui/signin-form.tsx
@@ -23,10 +23,13 @@ export default function SigninForm({ onSigninSuccess }: { onSigninSuccess?: () =
   const signinMutation = useSigninMutation()
 
   const handleSubmit = (data: SigninFormDataType) => {
-    signinMutation.mutate(data)
-    if (onSigninSuccess) {
-      onSigninSuccess()
-    }
+    signinMutation.mutate(data, {
+      onSuccess: () => {
+        if (onSigninSuccess) {
+          onSigninSuccess()
+        }
+      },
+    })
   }
 
   return (

--- a/src/features/auth/signup/ui/signup-form.tsx
+++ b/src/features/auth/signup/ui/signup-form.tsx
@@ -22,10 +22,16 @@ export default function SignupForm({ onSignupSuccess }: { onSignupSuccess?: () =
 
   const handleSubmit = (data: SignupFormDataType) => {
     const { email, name, password } = data // 회원가입 API 요청 데이터에는 비밀번호 확인 없음
-    signupMutation.mutateAsync({ email, name, password })
-    if (onSignupSuccess) {
-      onSignupSuccess()
-    }
+    signupMutation.mutateAsync(
+      { email, name, password },
+      {
+        onSuccess: () => {
+          if (onSignupSuccess) {
+            onSignupSuccess()
+          }
+        },
+      },
+    )
   }
 
   return (

--- a/src/features/auth/signup/ui/signup-form.tsx
+++ b/src/features/auth/signup/ui/signup-form.tsx
@@ -12,7 +12,7 @@ import { SignupSchema } from '../model/signup.schema'
 
 import type { SignupFormDataType, SignupInputData } from '../model/signup.type'
 
-export default function SignupForm() {
+export default function SignupForm({ onSignupSuccess }: { onSignupSuccess?: () => void }) {
   const signupMutation = useCustomMutation((data: SignupInputData) => postSignup(data))
 
   const methods = useForm<SignupFormDataType>({
@@ -23,6 +23,9 @@ export default function SignupForm() {
   const handleSubmit = (data: SignupFormDataType) => {
     const { email, name, password } = data // 회원가입 API 요청 데이터에는 비밀번호 확인 없음
     signupMutation.mutateAsync({ email, name, password })
+    if (onSignupSuccess) {
+      onSignupSuccess()
+    }
   }
 
   return (

--- a/src/features/auth/signup/ui/signup-modal.tsx
+++ b/src/features/auth/signup/ui/signup-modal.tsx
@@ -18,7 +18,7 @@ export default function SignupModal({ isSignupOpen, setSwitchModal, setClose }: 
         <ModalOverlay />
         <ModalContent>
           <ModalTitle className="text-center">회원가입</ModalTitle>
-          <SignupForm />
+          <SignupForm onSignupSuccess={() => setSwitchModal('EmailLogin')} />
 
           <Text typography="b2-normal" className="text-gray-80 flex gap-1 items-center justify-center mt-6">
             <span>이미 회원이신가요?</span>

--- a/src/shared/hooks/use-click-outside.ts
+++ b/src/shared/hooks/use-click-outside.ts
@@ -1,0 +1,19 @@
+import { useCallback, useEffect, type RefObject } from 'react'
+
+export default function useClickOutside(ref: RefObject<HTMLElement | null>, onClose: () => void) {
+  const handleClickOutside = useCallback(
+    (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        onClose()
+      }
+    },
+    [ref, onClose],
+  )
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [handleClickOutside])
+}

--- a/src/shared/ui/sidebar/sidebar.tsx
+++ b/src/shared/ui/sidebar/sidebar.tsx
@@ -1,8 +1,9 @@
 import { motion } from 'framer-motion'
+import { useRef, type ReactNode } from 'react'
+
+import useClickOutside from '@/shared/hooks/use-click-outside'
 
 import { useGNBContext } from '../gnb/gnb-conext'
-
-import type { ReactNode } from 'react'
 
 /**
  * @description 햄버거 버튼 클릭시 나타나는 사이드바 입니다
@@ -18,10 +19,15 @@ interface Props {
 }
 
 export default function SideBar({ children }: Props) {
-  const { isOpen } = useGNBContext()
+  const { isOpen, handleCloseSidebar } = useGNBContext()
+
+  const sidebarRef = useRef<HTMLElement>(null)
+
+  useClickOutside(sidebarRef, handleCloseSidebar)
 
   return (
     <motion.nav
+      ref={sidebarRef}
       initial="closed"
       animate={isOpen ? 'open' : 'closed'}
       exit="closed"


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

- close #166

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 로그인 성공 시 모달이 자동으로 닫히도록 처리
- 회원가입 성공 시 로그인 모달로 전환되도록 구현
- 로그인 및 회원가입 폼에 성공 시 실행할 콜백 함수를 Prop으로 전달하여, 향후 페이지 작업 시 리다이렉트 등 유연한 처리가 가능하도록 개선
- 사이드바 외부 클릭 시 자동으로 닫히도록 커스텀 훅으로 기능 추가

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

페이지는 모달 작업이 끝나기 전 임시로 쓰는 페이지로 만든거라 모달 전환만 처리했습니다
나래님께서 페이지도 사용하실 경우 리다이렉트 처리 추가하고, 아닐 경우 페이지 삭제 하겠습니다~~



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사이드바에서 바깥 영역을 클릭하면 자동으로 닫히는 기능이 추가되었습니다.

* **버그 수정**
  * 카카오 로그인 버튼이 로그인 선택 모달에서 비활성화되었습니다.

* **개선 사항**
  * 이메일 로그인 및 회원가입 성공 시, 모달 전환 및 상태 초기화가 자동으로 처리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->