### PR TITLE
feat: 일정 등록 tanstack query 

### DIFF
--- a/src/features/schedule-register/ui/schedule-register.tsx
+++ b/src/features/schedule-register/ui/schedule-register.tsx
@@ -7,6 +7,7 @@ import { useForm, useWatch, Controller } from 'react-hook-form'
 import { useNavigate } from 'react-router'
 import z from 'zod'
 
+import { scheduleQueryKeys } from '@/entities/schedule/models/schedule.query'
 import { IconAppointmentArrowLeft, IconQuestion, IconTemp } from '@/shared/assets/icons'
 import {
   BottomSheet,
@@ -275,7 +276,7 @@ export default function ScheduleRegister() {
   const scheduleRegisterMutate = useMutation({
     mutationFn: createSchedule,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['schedule'] })
+      queryClient.invalidateQueries({ queryKey: scheduleQueryKeys.all })
     },
   })
 

--- a/src/features/schedule-register/ui/schedule-register.tsx
+++ b/src/features/schedule-register/ui/schedule-register.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { format, addHours, setMilliseconds, setMinutes, setSeconds } from 'date-fns'
 import { ko } from 'date-fns/locale'
 import { useEffect, useState } from 'react'
@@ -84,7 +85,6 @@ export default function ScheduleRegister() {
   const onClickButton = () => {
     navigate(-1)
   }
-  //이전 페이지로 갈 수 없을 경우도 만들어야함
 
   //색 설정
   const [isColorOpen, setIsColorOpen] = useState(false)
@@ -204,7 +204,8 @@ export default function ScheduleRegister() {
               defaultValue={1}
               render={({ field }) => (
                 <Input
-                  className="w-12 px-4 py-2.5 text-center bg-gray-5 rounded-[0.25rem]"
+                  type="number"
+                  className="w-12 px-4 py-2.5 text-center bg-gray-5 rounded-[0.25rem] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
                   {...field}
                   onChange={(e) => field.onChange(Number(e.target.value))}
                 />
@@ -258,18 +259,25 @@ export default function ScheduleRegister() {
     setIsVisibleOpen(true)
   }
 
-  //완료 버튼을 누르지 않았을 때는 선택한 값이 반영되지 않아야 할 것 같음...
-
   //시간 string 형식으로 변환
   function dateToString(date: Date) {
     const year = date.getFullYear()
-    const month = String(date.getMonth() + 1).padStart(2, '0') // 0~11 이므로 +1
+    const month = String(date.getMonth() + 1).padStart(2, '0')
     const day = String(date.getDate()).padStart(2, '0')
     const hour = String(date.getHours()).padStart(2, '0')
     const minute = String(date.getMinutes()).padStart(2, '0')
 
     return `${year}-${month}-${day} ${hour}:${minute}`
   }
+
+  const queryClient = useQueryClient()
+
+  const scheduleRegisterMutate = useMutation({
+    mutationFn: createSchedule,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['schedule'] })
+    },
+  })
 
   //API
   const onSubmit = async (data: ScheduleFormType) => {
@@ -299,7 +307,7 @@ export default function ScheduleRegister() {
     }
 
     try {
-      const result = await createSchedule(payload)
+      const result = await scheduleRegisterMutate.mutateAsync(payload)
       devLog('log', 'result', result)
       navigate('/')
     } catch (error) {
@@ -466,21 +474,6 @@ export default function ScheduleRegister() {
                             <Radio value="day">일 단위 반복</Radio>
                             {field.value === 'day' && (
                               <div key="repeat-day" className="mt-2 flex flex-col gap-4 pl-6">
-                                <div className="flex items-center gap-2">
-                                  <Controller
-                                    control={methods.control}
-                                    name="interval"
-                                    defaultValue={1}
-                                    render={({ field }) => (
-                                      <Input
-                                        className="w-12 px-4 py-2.5 text-center bg-gray-5 rounded-[0.25rem]"
-                                        {...field}
-                                        onChange={(e) => field.onChange(Number(e.target.value))}
-                                      />
-                                    )}
-                                  />
-                                  <span>일 마다</span>
-                                </div>
                                 {renderRepeatDetailOptions()}
                               </div>
                             )}
@@ -489,21 +482,6 @@ export default function ScheduleRegister() {
                             <Radio value="week">주 단위 반복</Radio>
                             {field.value === 'week' && (
                               <div key="repeat-week" className="mt-2 flex flex-col gap-4 pl-6">
-                                <div className="flex items-center gap-2">
-                                  <Controller
-                                    control={methods.control}
-                                    name="interval"
-                                    defaultValue={1}
-                                    render={({ field }) => (
-                                      <Input
-                                        className="w-12 px-4 py-2.5 text-center bg-gray-5 rounded-[0.25rem]"
-                                        {...field}
-                                        onChange={(e) => field.onChange(Number(e.target.value))}
-                                      />
-                                    )}
-                                  />
-                                  <span>주 마다</span>
-                                </div>
                                 {renderRepeatDetailOptions()}
                               </div>
                             )}
@@ -512,21 +490,6 @@ export default function ScheduleRegister() {
                             <Radio value="month">월 단위 반복</Radio>
                             {field.value === 'month' && (
                               <div key="repeat-month" className="mt-2 flex flex-col gap-4 pl-6">
-                                <div className="flex items-center gap-2">
-                                  <Controller
-                                    control={methods.control}
-                                    name="interval"
-                                    defaultValue={1}
-                                    render={({ field }) => (
-                                      <Input
-                                        className="w-12 px-4 py-2.5 text-center bg-gray-5 rounded-[0.25rem]"
-                                        {...field}
-                                        onChange={(e) => field.onChange(Number(e.target.value))}
-                                      />
-                                    )}
-                                  />
-                                  <span>월 마다</span>
-                                </div>
                                 {renderRepeatDetailOptions()}
                               </div>
                             )}
@@ -535,21 +498,6 @@ export default function ScheduleRegister() {
                             <Radio value="year">연 단위 반복</Radio>
                             {field.value === 'year' && (
                               <div key="repeat-year" className="mt-2 flex flex-col gap-4 pl-6">
-                                <div className="flex items-center gap-2">
-                                  <Controller
-                                    control={methods.control}
-                                    name="interval"
-                                    defaultValue={1}
-                                    render={({ field }) => (
-                                      <Input
-                                        className="w-12 px-4 py-2.5 text-center bg-gray-5 rounded-[0.25rem]"
-                                        {...field}
-                                        onChange={(e) => field.onChange(Number(e.target.value))}
-                                      />
-                                    )}
-                                  />
-                                  <span>년 마다</span>
-                                </div>
                                 {renderRepeatDetailOptions()}
                               </div>
                             )}

--- a/src/features/schedule-register/ui/schedule-time-selector.tsx
+++ b/src/features/schedule-register/ui/schedule-time-selector.tsx
@@ -18,7 +18,7 @@ export default function TimeSelector<T extends string | number>({
   return (
     <div
       className={cn(
-        'flex flex-col items-center text-gray-90 p-2.5 h-[16.625rem] gap-y-2.5 overflow-y-scroll snap-y',
+        'flex flex-col items-center text-gray-90 p-2.5 h-[16.625rem] gap-y-2.5 overflow-y-scroll snap-y scrollbar-hide',
         className,
       )}
     >

--- a/src/shared/ui/radio/radio.tsx
+++ b/src/shared/ui/radio/radio.tsx
@@ -8,22 +8,25 @@ import Text from '../text/text'
 
 import { useRadioContext } from './radio-context'
 
-const radioVariants = cva('size-6 rounded-full border border-gray-400 flex items-center justify-center', {
-  variants: {
-    checked: {
-      true: 'border-primary-600 bg-primary-600',
-      false: 'bg-white',
+const radioVariants = cva(
+  'size-6 rounded-full border border-gray-400 flex items-center justify-center cursor-pointer',
+  {
+    variants: {
+      checked: {
+        true: 'border-primary-600 bg-primary-600',
+        false: 'bg-white',
+      },
+      disabled: {
+        true: 'border-gray-60 bg-gray-10 cursor-not-allowed',
+        false: '',
+      },
     },
-    disabled: {
-      true: 'border-gray-60 bg-gray-10 cursor-not-allowed',
-      false: '',
+    defaultVariants: {
+      checked: false,
+      disabled: false,
     },
   },
-  defaultVariants: {
-    checked: false,
-    disabled: false,
-  },
-})
+)
 
 interface Props extends InputHTMLAttributes<HTMLInputElement> {
   value: string
@@ -36,7 +39,7 @@ export default function Radio({ value, children, disabled, ...restProps }: Props
   const checked = value === selectedValue
 
   return (
-    <Text as="label" typography="b2-normal" className="flex gap-3 items-center">
+    <Text as="label" typography="b2-normal" className="flex gap-3 items-center cursor-pointer">
       <input
         type="radio"
         value={value}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #187 schedule register tanstack query 작업

ㅤ

## 📝 작업 내용

> tanstack query 작업
> timePicker 모달 스크롤 삭제
> 'n 일마다' 삭제
> input type='number'로 수정

ㅤ

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

ㅤ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 스케줄 등록 시 반복 횟수 입력란이 숫자 입력 전용으로 개선되고, 반복 상세 옵션 UI가 정리되었습니다.

* **버그 수정**
  * 시간 선택 영역의 스크롤바가 숨겨져 더 깔끔한 화면을 제공합니다.

* **스타일**
  * 라디오 버튼에 마우스 오버 시 포인터 커서가 적용되고, 비활성화 상태에서는 커서와 스타일이 명확하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->