### PR TITLE
feat:  [#197] 친구캘린더 헤더 뒤로가기 버튼 추가

### DIFF
--- a/src/shared/ui/calendar/ui/calendar-header-container.tsx
+++ b/src/shared/ui/calendar/ui/calendar-header-container.tsx
@@ -14,5 +14,7 @@ import type { ReactNode } from 'react'
  */
 
 export default function CalendarHeader({ children }: { children: ReactNode }) {
-  return <div className="sticky top-0 z-10 bg-white flex justify-between px-5 py-[0.625rem]">{children}</div>
+  return (
+    <div className="sticky top-0 z-10 bg-white flex items-center justify-between px-5 py-[0.625rem]">{children}</div>
+  )
 }

--- a/src/shared/ui/calendar/ui/calendar-header-content.tsx
+++ b/src/shared/ui/calendar/ui/calendar-header-content.tsx
@@ -1,4 +1,7 @@
 import { useState } from 'react'
+import { useNavigate } from 'react-router'
+
+import { IconAppointmentArrowLeft } from '@/shared/assets/icons'
 
 import ShareCalendarBottomSheet from '../../../../features/my-schedule/my-calendar/share-calendar-bottom-sheet'
 import { useCalendarContext } from '../hooks/calendar-context'
@@ -20,23 +23,38 @@ import CalendarHeaderMonthLabel from './calendar-header-month-label'
  */
 interface Props {
   showShareButton?: boolean
+  isFriendCalendar?: boolean
 }
-export default function CalendarHeaderContent({ showShareButton = false }: Props) {
+export default function CalendarHeaderContent({ showShareButton = false, isFriendCalendar = false }: Props) {
   const { containerRef, monthRefs } = useCalendarContext()
   const [isOpen, setIsOpen] = useState(false)
+  const navigate = useNavigate()
   return (
-    <>
-      <CalendarHeader>
-        <CalendarHeaderButton onClick={() => scrollToCurrentMonth(containerRef, monthRefs)}>오늘</CalendarHeaderButton>
-        <CalendarHeaderMonthLabel />
-        {showShareButton ? (
-          <CalendarHeaderButton onClick={() => setIsOpen(true)}>공유</CalendarHeaderButton>
-        ) : (
-          <div className="w-[1.625rem]" />
-        )}
-      </CalendarHeader>
-
-      {isOpen && <ShareCalendarBottomSheet isOpen={isOpen} setIsOpen={setIsOpen} />}
-    </>
+    <div>
+      {!isFriendCalendar ? (
+        <>
+          <CalendarHeader>
+            <CalendarHeaderButton onClick={() => scrollToCurrentMonth(containerRef, monthRefs)}>
+              오늘
+            </CalendarHeaderButton>
+            <CalendarHeaderMonthLabel />
+            {showShareButton ? (
+              <CalendarHeaderButton onClick={() => setIsOpen(true)}>공유</CalendarHeaderButton>
+            ) : (
+              <div className="w-[1.625rem]" />
+            )}
+          </CalendarHeader>
+          {isOpen && <ShareCalendarBottomSheet isOpen={isOpen} setIsOpen={setIsOpen} />}
+        </>
+      ) : (
+        <CalendarHeader>
+          <IconAppointmentArrowLeft className="size-4 cursor-pointer" onClick={() => navigate(-1)} />
+          <CalendarHeaderMonthLabel />
+          <CalendarHeaderButton onClick={() => scrollToCurrentMonth(containerRef, monthRefs)}>
+            오늘
+          </CalendarHeaderButton>
+        </CalendarHeader>
+      )}
+    </div>
   )
 }

--- a/src/widget/ui/calendar-ui.tsx
+++ b/src/widget/ui/calendar-ui.tsx
@@ -24,7 +24,7 @@ export default function CalendarUI({
       renderDateCellContent={renderDateCellContent}
       onDateClick={onDateClick}
     >
-      <CalendarHeaderContent showShareButton={showShareButton} />
+      <CalendarHeaderContent showShareButton={showShareButton} isFriendCalendar={true} />
       <CalendarDayName />
       <YearlyCalendar />
       {children}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #197 친구 캘린더 헤더 뒤로가기 버튼 추가
ㅤ

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 친구 캘린더 헤더 왼쪽 : 뒤로가기 버튼
- 오른쪽 : 오늘 날짜 이동 버튼
ㅤ

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

<img width="758" height="328" alt="image" src="https://github.com/user-attachments/assets/51a6cfb9-fa62-4fcf-bc1f-5b2e9f192fcd" />


## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

ㅤ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 친구 캘린더 화면에서 상단 헤더가 뒤로가기 버튼과 "오늘" 버튼만 표시되도록 변경되었습니다.
* **Style**
  * 캘린더 헤더의 레이아웃이 개선되어 버튼과 텍스트가 세로 중앙 정렬됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->