### PR TITLE
fix: [#207] 캘린더 헤더 수정

### DIFF
--- a/src/features/friend-schedule/ui/friend-calendar.tsx
+++ b/src/features/friend-schedule/ui/friend-calendar.tsx
@@ -36,6 +36,7 @@ export default function FriendCalendar() {
       disablePastDateStyling
       renderDateCellContent={(date) => <DateCellContent scheduleMap={scheduleMap} date={date} />}
       onDateClick={handleDateClick}
+      isFriendCalendar={true}
     >
       <AddScheduleButton onClick={goToCreateAppointment}>
         <IconCalendarAdd />

--- a/src/features/share-schedule/share-calendar/share-calendar.tsx
+++ b/src/features/share-schedule/share-calendar/share-calendar.tsx
@@ -32,6 +32,7 @@ export default function ShareCalendar() {
       disablePastDateStyling={false}
       renderDateCellContent={(date) => DateCellContent({ scheduleMap, date, isPast: isPastDate(date) })}
       onDateClick={(date) => handleDateClick(date, navigate)}
+      isShareCalendar={true}
     >
       <AddScheduleButton onClick={goToCreateAppointment}>
         <IconInvite />

--- a/src/shared/ui/calendar/ui/calendar-header-content.tsx
+++ b/src/shared/ui/calendar/ui/calendar-header-content.tsx
@@ -24,37 +24,50 @@ import CalendarHeaderMonthLabel from './calendar-header-month-label'
 interface Props {
   showShareButton?: boolean
   isFriendCalendar?: boolean
+  isShareCalendar?: boolean
 }
-export default function CalendarHeaderContent({ showShareButton = false, isFriendCalendar = false }: Props) {
+export default function CalendarHeaderContent({
+  showShareButton = false,
+  isFriendCalendar = false,
+  isShareCalendar = false,
+}: Props) {
   const { containerRef, monthRefs } = useCalendarContext()
   const [isOpen, setIsOpen] = useState(false)
   const navigate = useNavigate()
+
+  if (isFriendCalendar) {
+    return (
+      <CalendarHeader>
+        <IconAppointmentArrowLeft className="size-4 cursor-pointer" onClick={() => navigate(-1)} />
+        <CalendarHeaderMonthLabel />
+        <CalendarHeaderButton onClick={() => scrollToCurrentMonth(containerRef, monthRefs)}>오늘</CalendarHeaderButton>
+      </CalendarHeader>
+    )
+  }
+
+  if (isShareCalendar) {
+    return (
+      <CalendarHeader>
+        <div className="w-[1.625rem]" />
+        <CalendarHeaderMonthLabel />
+        <CalendarHeaderButton onClick={() => scrollToCurrentMonth(containerRef, monthRefs)}>오늘</CalendarHeaderButton>
+      </CalendarHeader>
+    )
+  }
+
+  // 기본값 (내 캘린더)
   return (
-    <div>
-      {isFriendCalendar ? (
-        <>
-          <CalendarHeader>
-            <CalendarHeaderButton onClick={() => scrollToCurrentMonth(containerRef, monthRefs)}>
-              오늘
-            </CalendarHeaderButton>
-            <CalendarHeaderMonthLabel />
-            {showShareButton ? (
-              <CalendarHeaderButton onClick={() => setIsOpen(true)}>공유</CalendarHeaderButton>
-            ) : (
-              <div className="w-[1.625rem]" />
-            )}
-          </CalendarHeader>
-          {isOpen && <ShareCalendarBottomSheet isOpen={isOpen} setIsOpen={setIsOpen} />}
-        </>
-      ) : (
-        <CalendarHeader>
-          <IconAppointmentArrowLeft className="size-4 cursor-pointer" onClick={() => navigate(-1)} />
-          <CalendarHeaderMonthLabel />
-          <CalendarHeaderButton onClick={() => scrollToCurrentMonth(containerRef, monthRefs)}>
-            오늘
-          </CalendarHeaderButton>
-        </CalendarHeader>
-      )}
-    </div>
+    <>
+      <CalendarHeader>
+        <CalendarHeaderButton onClick={() => scrollToCurrentMonth(containerRef, monthRefs)}>오늘</CalendarHeaderButton>
+        <CalendarHeaderMonthLabel />
+        {showShareButton ? (
+          <CalendarHeaderButton onClick={() => setIsOpen(true)}>공유</CalendarHeaderButton>
+        ) : (
+          <div className="w-[1.625rem]" />
+        )}
+      </CalendarHeader>
+      {isOpen && <ShareCalendarBottomSheet isOpen={isOpen} setIsOpen={setIsOpen} />}
+    </>
   )
 }

--- a/src/shared/ui/calendar/ui/calendar-header-content.tsx
+++ b/src/shared/ui/calendar/ui/calendar-header-content.tsx
@@ -31,7 +31,7 @@ export default function CalendarHeaderContent({ showShareButton = false, isFrien
   const navigate = useNavigate()
   return (
     <div>
-      {!isFriendCalendar ? (
+      {isFriendCalendar ? (
         <>
           <CalendarHeader>
             <CalendarHeaderButton onClick={() => scrollToCurrentMonth(containerRef, monthRefs)}>

--- a/src/widget/ui/calendar-ui.tsx
+++ b/src/widget/ui/calendar-ui.tsx
@@ -9,6 +9,8 @@ interface Props {
   onDateClick?: (date: Date) => void
   children?: ReactNode
   showShareButton?: boolean
+  isFriendCalendar?: boolean
+  isShareCalendar?: boolean
 }
 
 export default function CalendarUI({
@@ -16,6 +18,8 @@ export default function CalendarUI({
   renderDateCellContent,
   onDateClick,
   showShareButton = false,
+  isFriendCalendar = false,
+  isShareCalendar = false,
   children,
 }: Props) {
   return (
@@ -24,7 +28,11 @@ export default function CalendarUI({
       renderDateCellContent={renderDateCellContent}
       onDateClick={onDateClick}
     >
-      <CalendarHeaderContent showShareButton={showShareButton} isFriendCalendar={true} />
+      <CalendarHeaderContent
+        showShareButton={showShareButton}
+        isFriendCalendar={isFriendCalendar}
+        isShareCalendar={isShareCalendar}
+      />
       <CalendarDayName />
       <YearlyCalendar />
       {children}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #207 
ㅤ

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 친구의 캘린더 헤더: 뒤로가기, 오늘버튼
- 내 캘린더 헤더: 오늘, 공유하기버튼
- 공유캘린더 헤더: 오늘버튼
- 내 캘린더 헤더에 친구의 캘린더 헤더 적용되어 있어서 수정

ㅤ

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

ㅤ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 캘린더 헤더의 표시 조건이 수정되어, 친구 캘린더일 때와 아닐 때 각각 올바른 헤더가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->