### PR TITLE
fix: [#213] 연속일정 버그 수정

### DIFF
--- a/src/entities/schedule/models/get-group-by-date.ts
+++ b/src/entities/schedule/models/get-group-by-date.ts
@@ -1,15 +1,32 @@
-import { format } from 'date-fns'
+import { format, eachDayOfInterval } from 'date-fns'
 
 import type { Schedule } from './schedule.types'
 
 export default function groupByDate(schedules: Schedule[]) {
   const map: Record<string, Schedule[]> = {}
+
   for (const schedule of schedules) {
-    const date = format(new Date(schedule.startAt), 'yyyy-MM-dd')
-    if (!map[date]) {
-      map[date] = []
+    // 반복 일정이면 startAt만 사용
+    if (schedule.isRepeated) {
+      const date = format(new Date(schedule.startAt), 'yyyy-MM-dd')
+      if (!map[date]) {
+        map[date] = []
+      }
+      map[date].push(schedule)
+    } else {
+      const start = new Date(schedule.startAt)
+      const end = new Date(schedule.endAt)
+      const days = eachDayOfInterval({ start, end })
+
+      for (const day of days) {
+        const dateStr = format(day, 'yyyy-MM-dd')
+        if (!map[dateStr]) {
+          map[dateStr] = []
+        }
+        map[dateStr].push(schedule)
+      }
     }
-    map[date].push(schedule)
   }
+
   return map
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closed #213 

ㅤ

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 연속 일정 등록시 일정뱃지가 해당하는 날짜들에 표시가 안되는 버그 수정
ㅤ

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요
<img width="818" height="1014" alt="image" src="https://github.com/user-attachments/assets/4b0c9b2b-863e-4a9e-9c03-38c9bb19a170" />

## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

ㅤ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 반복되지 않는 일정이 여러 날짜에 걸쳐 있을 경우, 각 날짜별로 일정을 올바르게 그룹화하도록 개선되었습니다. 이제 반복되지 않는 일정은 시작일과 종료일 사이의 모든 날짜에 포함되어 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->