### PR TITLE
feat: [#218] 약속일정 뱃지 추가

### DIFF
--- a/src/shared/ui/calendar/ui/calendar-cell.tsx
+++ b/src/shared/ui/calendar/ui/calendar-cell.tsx
@@ -37,7 +37,7 @@ export default function CalendarCell({ year, month, date, showMonthLabel }: Prop
   const monthLabel = String(month + 1).padStart(2, '0')
 
   return (
-    <button onClick={() => onDateClick?.(fullDate)} className=" h-20 flex flex-col border-t border-gray-10">
+    <button onClick={() => onDateClick?.(fullDate)} className="w-full h-20 flex flex-col border-t border-gray-10">
       <div className="relative flex justify-center mb-1">
         <Text
           as="span"
@@ -55,7 +55,7 @@ export default function CalendarCell({ year, month, date, showMonthLabel }: Prop
         )}
       </div>
 
-      <div>{renderDateCellContent?.(fullDate)}</div>
+      <div className="w-full">{renderDateCellContent?.(fullDate)}</div>
     </button>
   )
 }

--- a/src/shared/ui/calendar/ui/date-cell-content.tsx
+++ b/src/shared/ui/calendar/ui/date-cell-content.tsx
@@ -2,7 +2,7 @@
 
 import { format } from 'date-fns'
 
-import { PrivateSchedule, ScheduleBadgeFill } from '@/shared/ui/calendar'
+import { PrivateSchedule, ScheduleBadgeFill, ScheduleBadgeMarker } from '@/shared/ui/calendar'
 import Text from '@/shared/ui/text/text'
 
 import type { Schedule } from '@/entities/schedule'
@@ -22,16 +22,27 @@ export default function DateCellContent({ scheduleMap, date, isPast = false, isM
 
   return (
     <div className="flex flex-col gap-1 w-full px-1">
-      {!isPast && // 과거 날짜가 아닐 때만 표시
-        visible.map((item) =>
-          isMine || item.isVisible ? (
+      {!isPast &&
+        visible.map((item) => {
+          if (!(isMine || item.isVisible)) {
+            return <PrivateSchedule key={item.title} />
+          }
+
+          if (item.appointmentId) {
+            return (
+              <ScheduleBadgeMarker key={item.title} color={item.color}>
+                {item.title}
+              </ScheduleBadgeMarker>
+            )
+          }
+
+          return (
             <ScheduleBadgeFill key={item.title} color={item.color}>
               {item.title}
             </ScheduleBadgeFill>
-          ) : (
-            <PrivateSchedule key={item.title} />
-          ),
-        )}
+          )
+        })}
+
       {!isPast && hiddenCount > 0 && (
         <Text as="span" typography="caption-10" className="w-full text-left text-gray-80 z-base">
           +{hiddenCount}

--- a/src/shared/ui/calendar/ui/schedule-badge-fill.tsx
+++ b/src/shared/ui/calendar/ui/schedule-badge-fill.tsx
@@ -15,17 +15,20 @@ interface Props extends VariantProps<typeof badgeVariants> {
   children: ReactNode
 }
 
-const badgeVariants = cva('h-3 px-0.5 w-full text-white rounded-sm z-base truncate overflow-hidden whitespace-nowrap', {
-  variants: {
-    color: {
-      RED: 'bg-calendar-red',
-      YELLOW: 'bg-calendar-yellow',
-      GREEN: 'bg-calendar-green',
-      BLUE: 'bg-calendar-blue',
-      PURPLE: 'bg-calendar-purple',
+const badgeVariants = cva(
+  'block h-3 w-full px-0.5 text-white rounded-sm z-base truncate overflow-hidden whitespace-nowrap max-w-full min-w-0',
+  {
+    variants: {
+      color: {
+        RED: 'bg-calendar-red',
+        YELLOW: 'bg-calendar-yellow',
+        GREEN: 'bg-calendar-green',
+        BLUE: 'bg-calendar-blue',
+        PURPLE: 'bg-calendar-purple',
+      },
     },
   },
-})
+)
 
 export default function ScheduleBadgeFill({ children, color }: Props) {
   return (

--- a/src/shared/ui/calendar/ui/schedule-badge-marker.tsx
+++ b/src/shared/ui/calendar/ui/schedule-badge-marker.tsx
@@ -17,23 +17,23 @@ interface Props extends VariantProps<typeof badgeVariants> {
   children: ReactNode
 }
 
-const badgeVariants = cva('w-1 h-3 text-black rounded-sm z-base truncate overflow-hidden whitespace-nowrap', {
+const badgeVariants = cva('w-1 min-w-1 h-3 rounded-sm z-base', {
   variants: {
     color: {
-      redAlt: 'bg-calendar-red-alt',
-      yellowAlt: 'bg-calendar-yellow-alt',
-      greenAlt: 'bg-calendar-green-alt',
-      blueAlt: 'bg-calendar-blue-alt',
-      purpleAlt: 'bg-calendar-purple-alt',
+      RED: 'bg-calendar-red',
+      YELLOW: 'bg-calendar-yellow',
+      GREEN: 'bg-calendar-green',
+      BLUE: 'bg-calendar-blue',
+      PURPLE: 'bg-calendar-purple',
     },
   },
 })
 
 export default function ScheduleBadgeMarker({ children, color }: Props) {
   return (
-    <div className="flex items-center gap-1 w-full">
+    <div className="flex items-center gap-1 w-full z-base">
       <div className={badgeVariants({ color })} />
-      <Text as="span" typography="caption-10">
+      <Text as="span" typography="caption-10" className="min-w-0 truncate overflow-hidden whitespace-nowrap">
         {children}
       </Text>
     </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #218 

ㅤ

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
약속 일정일 경우 뱃지 다르게 표시 

ㅤ

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요
<img width="376" height="202" alt="image" src="https://github.com/user-attachments/assets/94134738-020e-4244-9c65-f3f242ebbf81" />

## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

ㅤ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 캘린더 셀과 내부 콘텐츠의 너비가 전체 영역을 차지하도록 스타일이 개선되었습니다.
  * 일정 배지 및 마커의 시각적 스타일과 텍스트 표시 방식이 개선되었습니다.

* **신규 기능**
  * 일정 항목에 appointmentId가 있는 경우, 새로운 스타일의 일정 배지가 표시됩니다.

* **버그 수정**
  * 일정 배지의 텍스트가 길 경우 잘림 및 오버플로우 처리가 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->