### PR TITLE
feat: [#236] 데스크탑에서 모바일처럼 중앙 고정형 레이아웃 적용

### DIFF
--- a/src/pages/main-layout.tsx
+++ b/src/pages/main-layout.tsx
@@ -4,9 +4,11 @@ import GNBWrapper from '@/features/auth/gnb/ui/gnb-wrapper'
 
 export default function MainLayout() {
   return (
-    <>
-      <GNBWrapper />
-      <Outlet />
-    </>
+    <div className="flex justify-center lg:px-8 bg-gray-5 h-[100vh]">
+      <div className="w-full max-w-[640px] bg-white relative overflow-hidden">
+        <GNBWrapper />
+        <Outlet />
+      </div>
+    </div>
   )
 }

--- a/src/shared/ui/bottom-sheet/bottom-sheet-container.tsx
+++ b/src/shared/ui/bottom-sheet/bottom-sheet-container.tsx
@@ -7,7 +7,7 @@ import { useBottomSheetContext } from './bottom-sheet-context'
 import type { HTMLAttributes } from 'react'
 
 const containerVariants = cva(
-  'fixed bottom-0 left-0 w-full h-2/5 z-modal bg-white rounded-t-[1.5rem] shadow-[0_-4px_12px_0_rgba(0,0,0,0.08)] px-6 pt-8',
+  'fixed bottom-0 left-0 w-full max-w-[640px] sm:left-1/2 sm:-translate-x-1/2 h-2/5 z-modal bg-white rounded-t-[1.5rem] shadow-[0_-4px_12px_0_rgba(0,0,0,0.08)] px-6 pt-8',
   {
     variants: {
       isOpen: {

--- a/src/shared/ui/float-button/float-button.tsx
+++ b/src/shared/ui/float-button/float-button.tsx
@@ -4,23 +4,26 @@ import { cn, Slot } from '@/shared/utils'
 
 import type { ButtonHTMLAttributes } from 'react'
 
-const FloatButtonVariants = cva('bg-gray-20 flex items-center justify-center shadow-md fixed bottom-5 right-4', {
-  variants: {
-    shape: {
-      circle: 'rounded-full',
-      square: 'rounded-lg',
+const FloatButtonVariants = cva(
+  'bg-gray-20 flex items-center justify-center shadow-xl absolute opacity-85 bottom-5 right-4',
+  {
+    variants: {
+      shape: {
+        circle: 'rounded-full',
+        square: 'rounded-lg',
+      },
+      size: {
+        small: 'size-8',
+        medium: 'size-12',
+        large: 'size-16',
+      },
     },
-    size: {
-      small: 'size-8',
-      medium: 'size-12',
-      large: 'size-16',
+    defaultVariants: {
+      shape: 'circle',
+      size: 'medium',
     },
   },
-  defaultVariants: {
-    shape: 'circle',
-    size: 'medium',
-  },
-})
+)
 
 interface Props extends ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof FloatButtonVariants> {
   asChild?: boolean

--- a/src/shared/ui/sidebar/sidebar.tsx
+++ b/src/shared/ui/sidebar/sidebar.tsx
@@ -39,7 +39,7 @@ export default function SideBar({ children }: Props) {
       exit="closed"
       variants={sidebarVariants}
       transition={{ type: 'tween', duration: 0.3 }}
-      className="w-[16rem] h-full fixed top-0 right-0 flex flex-col justify-between bg-white p-[0.625rem] z-side-bar rounded-s-lg"
+      className="w-[16rem] h-full absolute top-0 right-0 flex flex-col justify-between bg-white p-[0.625rem] z-side-bar rounded-s-lg"
     >
       {children}
     </motion.nav>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

- close #236

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 데스크탑에서도 모바일 크기로 확인할 수 있도록 레이아웃 적용
- fixed 요소들 absolute로 변경 or 위치 수정

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

<img width="1423" height="845" alt="image" src="https://github.com/user-attachments/assets/48109eb9-7b17-46fc-9568-9ddf76ce520d" />


## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

스크린샷과 같이 보여지는데 테일윈드 모바일 기준 크기 640px이라서 거기에 맞췄습니다
모바일 일 경우 (640px 미만) 기존처럼 가로 길이에 맞춘 레이아웃이 보여집니다
모바일 이상일 경우(640px 이상) 사진처럼 페이지 가로 길이는 고정된채 여백만 늘어납니다

채널톡은 좌우만 선택하고 세부적으로는 설정 불가해서 계속 왼쪽에 위치할 것 같습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * 메인 레이아웃에 최대 너비, 배경색, 패딩 등 레이아웃 스타일이 개선되었습니다.
  * 바텀시트 컨테이너가 최대 640px 너비로 제한되고, 큰 화면에서 중앙 정렬됩니다.
  * 플로팅 버튼의 위치, 그림자, 투명도 및 크기 옵션이 개선되었습니다.
  * 사이드바의 위치 지정 방식이 변경되어 레이아웃 일관성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->