### PR TITLE
fix: [#286] 공유캘린더 오늘 이전 날짜 뱃지 안보이게 수정

### DIFF
--- a/src/features/share-schedule/ui/share-calendar.tsx
+++ b/src/features/share-schedule/ui/share-calendar.tsx
@@ -42,7 +42,7 @@ export default function ShareCalendar() {
         <HeaderTodayButton>오늘</HeaderTodayButton>
       </HeaderContainer>
       <InfiniteCalendar disablePrev isPast>
-        {(date) => <RenderScheduleBadges date={date} scheduleMap={scheduleMap} />}
+        {(date) => <RenderScheduleBadges date={date} scheduleMap={scheduleMap} isShareCalendar />}
       </InfiniteCalendar>
       <FloatButton className="bg-primary-60" size="large" onClick={goToCreateAppointment}>
         <IconInvite className="size-8" />

--- a/src/shared/ui/calendar/ui/render-schedule-badges.tsx
+++ b/src/shared/ui/calendar/ui/render-schedule-badges.tsx
@@ -1,4 +1,4 @@
-import { format } from 'date-fns'
+import { format, isBefore, startOfDay } from 'date-fns'
 
 import { AppointmentBadge, PrivateScheduleBadge, Text } from '@/shared/ui'
 import { ScheduleBadge } from '@/shared/ui/calendar'
@@ -9,13 +9,23 @@ interface Props {
   date: Date
   scheduleMap: Record<string, Schedule[]>
   isMyCalendar?: boolean
+  isShareCalendar?: boolean
 }
 
-export default function RenderScheduleBadges({ date, scheduleMap, isMyCalendar = false }: Props) {
+export default function RenderScheduleBadges({
+  date,
+  scheduleMap,
+  isMyCalendar = false,
+  isShareCalendar = false,
+}: Props) {
   const key = format(date, 'yyyy-MM-dd')
   const schedules = scheduleMap[key] ?? []
   const visible = schedules.slice(0, 1)
   const hiddenCount = schedules.length - visible.length
+
+  if (isShareCalendar && isBefore(startOfDay(date), startOfDay(new Date()))) {
+    return null
+  }
 
   const renderBadge = (schedule: Schedule) => {
     const BadgeComponent = schedule.appointmentId ? AppointmentBadge : ScheduleBadge


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #286 

ㅤ

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 공유캘린더 오늘 이전 날짜 뱃지 안보이게 수정
ㅤ

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

ㅤ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 공유 캘린더 모드에서 과거 날짜의 일정 배지가 표시되지 않도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->