### PR TITLE
feat: [#278] calendar-ui 스토리북 작성

### DIFF
--- a/src/shared/ui/calendar/ui/appontment-badge.stories.tsx
+++ b/src/shared/ui/calendar/ui/appontment-badge.stories.tsx
@@ -1,0 +1,48 @@
+import AppointmentBadge from './appointment-badge'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta: Meta<typeof AppointmentBadge> = {
+  title: 'shared/calendar/appointment-badge',
+  component: AppointmentBadge,
+  tags: ['autodocs'],
+  argTypes: {},
+}
+export default meta
+
+type Story = StoryObj<typeof AppointmentBadge>
+
+export const Red: Story = {
+  args: {
+    color: 'RED',
+    children: '레드약속',
+  },
+}
+
+export const Blue: Story = {
+  args: {
+    color: 'BLUE',
+    children: '블루약속',
+  },
+}
+
+export const Yellow: Story = {
+  args: {
+    color: 'YELLOW',
+    children: '옐로우약속',
+  },
+}
+
+export const Green: Story = {
+  args: {
+    color: 'GREEN',
+    children: '그린약속',
+  },
+}
+
+export const Purple: Story = {
+  args: {
+    color: 'PURPLE',
+    children: '퍼플약속',
+  },
+}

--- a/src/shared/ui/calendar/ui/calendar-cell.stories.tsx
+++ b/src/shared/ui/calendar/ui/calendar-cell.stories.tsx
@@ -1,0 +1,51 @@
+import AppointmentBadge from './appointment-badge'
+import CalendarCell from './calendar-cell'
+import { CalendarProvider } from './calendar-context'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const mockContextValue = {
+  visibleMonth: { year: 2025, month: 8 },
+  setVisibleMonth: () => {},
+}
+
+const meta: Meta<typeof CalendarCell> = {
+  title: 'shared/calendar/calendar-cell',
+  component: CalendarCell,
+  decorators: [
+    (Story) => (
+      <CalendarProvider value={mockContextValue}>
+        <Story />
+      </CalendarProvider>
+    ),
+  ],
+  tags: ['autodocs'],
+  argTypes: {},
+}
+export default meta
+
+type Story = StoryObj<typeof CalendarCell>
+
+export const MonthOfFirstDate: Story = {
+  render: (args) => (
+    <CalendarCell {...args}>
+      <AppointmentBadge color="RED">약속일정</AppointmentBadge>
+    </CalendarCell>
+  ),
+  args: {
+    date: { year: 2025, month: 8, day: 1 },
+    showMonthLabel: true,
+  },
+}
+
+export const Date: Story = {
+  render: (args) => (
+    <CalendarCell {...args}>
+      <AppointmentBadge color="BLUE">약속일정</AppointmentBadge>
+    </CalendarCell>
+  ),
+  args: {
+    date: { year: 2025, month: 8, day: 10 },
+    showMonthLabel: false,
+  },
+}

--- a/src/shared/ui/calendar/ui/header-button.stories.tsx
+++ b/src/shared/ui/calendar/ui/header-button.stories.tsx
@@ -1,0 +1,17 @@
+import HeaderButton from './header-button'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta: Meta<typeof HeaderButton> = {
+  title: 'shared/calendar/header-button',
+  component: HeaderButton,
+  tags: ['autodocs'],
+  argTypes: {},
+}
+export default meta
+
+type Story = StoryObj<typeof HeaderButton>
+
+export const ShareButton: Story = {
+  args: { children: '공유하기' },
+}

--- a/src/shared/ui/calendar/ui/header-month-label.stories.tsx
+++ b/src/shared/ui/calendar/ui/header-month-label.stories.tsx
@@ -1,0 +1,68 @@
+import { format } from 'date-fns'
+import { useState } from 'react'
+
+import { CalendarProvider } from './calendar-context'
+import HeaderMonthLabel from './header-month-label'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const mockContextValue = {
+  visibleMonth: { year: 2025, month: 8 },
+  setVisibleMonth: () => {},
+}
+
+const meta: Meta<typeof HeaderMonthLabel> = {
+  title: 'shared/calendar/header-month-label',
+  component: HeaderMonthLabel,
+  decorators: [
+    (Story) => (
+      <CalendarProvider value={mockContextValue}>
+        <Story />
+      </CalendarProvider>
+    ),
+  ],
+  tags: ['autodocs'],
+  argTypes: {},
+}
+export default meta
+
+type Story = StoryObj<typeof HeaderMonthLabel>
+
+export const CurrentMonth: Story = {}
+
+export const NextMonth: Story = {
+  render: () => {
+    const currentYear = Number(format(new Date(), 'yyyy'))
+    const currentMonth = Number(format(new Date(), 'MM'))
+    const [monthState, setMonthState] = useState({ year: currentYear, month: currentMonth })
+
+    const handleNextMonth = () => {
+      setMonthState((prev) => {
+        const nextMonth = prev.month === 12 ? 1 : prev.month + 1
+        const nextYear = prev.month === 12 ? prev.year + 1 : prev.year
+        return { year: nextYear, month: nextMonth }
+      })
+    }
+
+    const handlePrevMonth = () => {
+      setMonthState((prev) => {
+        const prevMonth = prev.month === 1 ? 12 : prev.month - 1
+        const prevYear = prev.month === 1 ? prev.year - 1 : prev.year
+        return { year: prevYear, month: prevMonth }
+      })
+    }
+
+    return (
+      <CalendarProvider
+        value={{
+          visibleMonth: monthState,
+          setVisibleMonth: handleNextMonth,
+        }}
+      >
+        <button onClick={handlePrevMonth}>이전달 보기</button>
+        <HeaderMonthLabel />
+        <button onClick={handleNextMonth}>다음달 보기</button>
+      </CalendarProvider>
+    )
+  },
+}

--- a/src/shared/ui/calendar/ui/infinite-calendar.stories.tsx
+++ b/src/shared/ui/calendar/ui/infinite-calendar.stories.tsx
@@ -1,0 +1,39 @@
+import { CalendarProvider } from './calendar-context'
+import InfiniteCalendar from './infinite-calendar'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta: Meta<typeof InfiniteCalendar> = {
+  title: 'shared/calendar/infinite-calendar',
+  component: InfiniteCalendar,
+  decorators: [
+    (Story) => {
+      const mockContextValue = {
+        visibleMonth: { year: 2025, month: 8 },
+        setVisibleMonth: () => {},
+        setSelectedDate: () => {},
+        selectedDate: null,
+        setVisibleYear: () => {},
+      }
+
+      return (
+        <div style={{ height: '80vh', border: '1px solid gray' }}>
+          <CalendarProvider value={mockContextValue}>
+            <Story />
+          </CalendarProvider>
+        </div>
+      )
+    },
+  ],
+}
+export default meta
+
+type Story = StoryObj<typeof InfiniteCalendar>
+
+export const Calendar: Story = {
+  render: () => <InfiniteCalendar />,
+}
+
+export const ShareCalendar: Story = {
+  render: () => <InfiniteCalendar disablePrev />,
+}

--- a/src/shared/ui/calendar/ui/monthly-calendar.stories.tsx
+++ b/src/shared/ui/calendar/ui/monthly-calendar.stories.tsx
@@ -1,0 +1,44 @@
+import { format } from 'date-fns'
+
+import { CalendarProvider } from './calendar-context'
+import MonthlyCalendar from './monthly-calendar'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta: Meta<typeof MonthlyCalendar> = {
+  title: 'shared/calendar/monthly-calendar',
+  component: MonthlyCalendar,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => {
+      const mockContextValue = {
+        visibleMonth: { year: 2025, month: 8 },
+        setVisibleMonth: () => {},
+        setSelectedDate: () => {},
+        selectedDate: null,
+        setVisibleYear: () => {},
+      }
+
+      return (
+        <div>
+          <CalendarProvider value={mockContextValue}>
+            <Story />
+          </CalendarProvider>
+        </div>
+      )
+    },
+  ],
+  argTypes: {},
+}
+export default meta
+
+type Story = StoryObj<typeof MonthlyCalendar>
+
+const currentYear = Number(format(new Date(), 'yyyy'))
+const currentMonth = Number(format(new Date(), 'MM')) - 1
+export const Default: Story = {
+  args: {
+    year: currentYear,
+    month: currentMonth,
+  },
+}

--- a/src/shared/ui/calendar/ui/private-schedule-badge.stories.tsx
+++ b/src/shared/ui/calendar/ui/private-schedule-badge.stories.tsx
@@ -1,0 +1,24 @@
+import PrivateScheduleBadge from './private-schedule-badge'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta: Meta<typeof PrivateScheduleBadge> = {
+  title: 'shared/calendar/private-schedule-badge',
+  component: PrivateScheduleBadge,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => {
+      return (
+        <div style={{ width: '80px' }}>
+          <Story />
+        </div>
+      )
+    },
+  ],
+  argTypes: {},
+}
+export default meta
+
+type Story = StoryObj<typeof PrivateScheduleBadge>
+
+export const Default: Story = {}

--- a/src/shared/ui/calendar/ui/private-schedule-modal.stories.tsx
+++ b/src/shared/ui/calendar/ui/private-schedule-modal.stories.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react'
+
+import PrivateScheduleModal from './private-schedule-modal'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta: Meta<typeof PrivateScheduleModal> = {
+  title: 'shared/calendar/private-schedule-modal',
+  component: PrivateScheduleModal,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => {
+      return (
+        <div>
+          <Story />
+        </div>
+      )
+    },
+  ],
+  argTypes: {},
+}
+export default meta
+
+type Story = StoryObj<typeof PrivateScheduleModal>
+
+export const Default: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false)
+    const handleModal = () => setIsOpen(true)
+
+    return (
+      <>
+        <button onClick={handleModal}>모달열기</button>
+
+        {isOpen && <PrivateScheduleModal isOpen={isOpen} setIsOpen={setIsOpen} />}
+      </>
+    )
+  },
+}

--- a/src/shared/ui/calendar/ui/render-schedule-badge.stories.tsx
+++ b/src/shared/ui/calendar/ui/render-schedule-badge.stories.tsx
@@ -1,0 +1,75 @@
+import RenderScheduleBadges from './render-schedule-badges'
+
+import type { Schedule } from '@/entities/schedule'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta: Meta<typeof RenderScheduleBadges> = {
+  title: 'shared/calendar/render-schedule-badge',
+  component: RenderScheduleBadges,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => {
+      return (
+        <div style={{ width: '80px' }}>
+          <Story />
+        </div>
+      )
+    },
+  ],
+  argTypes: {},
+}
+export default meta
+
+type Story = StoryObj<typeof RenderScheduleBadges>
+
+const mockData: Record<string, Schedule[]> = {
+  '2025-09-01': [
+    {
+      scheduleId: 12,
+      title: '9월 비공개 일정',
+      content: '일정',
+      startAt: '2025-09-01 10:00',
+      endAt: '2025-09-01 10:00',
+      isRepeated: true,
+      repeatRule: 'WEEKLY',
+      isVisible: false,
+      createdAt: '2025-07-23T01:02:10.821353',
+      modifiedAt: '2025-07-23T01:02:10.821353',
+      isAllDay: false,
+      repeatType: 'DATE',
+      repeatCount: 2,
+      repeatEndAt: '2025-07-30 14:00',
+      color: 'RED',
+      userId: 9,
+      appointmentId: null,
+    },
+    {
+      scheduleId: 1,
+      title: '9월 공개 일정',
+      content: '일정',
+      startAt: '2025-08-01 10:00',
+      endAt: '2025-08-01 10:00',
+      isRepeated: true,
+      repeatRule: 'WEEKLY',
+      isVisible: false,
+      createdAt: '2025-07-23T01:02:10.821353',
+      modifiedAt: '2025-07-23T01:02:10.821353',
+      isAllDay: false,
+      repeatType: 'DATE',
+      repeatCount: 2,
+      repeatEndAt: '2025-07-30 14:00',
+      color: 'RED',
+      userId: 9,
+      appointmentId: null,
+    },
+  ],
+}
+const date = new Date('2025-09-01T00:00:00')
+
+export const IsMyCalendar: Story = {
+  args: { date: date, scheduleMap: mockData, isMyCalendar: true },
+}
+
+export const IsShareCalendar: Story = {
+  args: { date: date, scheduleMap: mockData, isShareCalendar: true },
+}

--- a/src/shared/ui/calendar/ui/schedule-badge.stories.tsx
+++ b/src/shared/ui/calendar/ui/schedule-badge.stories.tsx
@@ -1,0 +1,33 @@
+import ScheduleBadge from './schedule-badge'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta: Meta<typeof ScheduleBadge> = {
+  title: 'shared/calendar/schedule-badge',
+  component: ScheduleBadge,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => {
+      return (
+        <div style={{ width: '80px' }}>
+          <Story />
+        </div>
+      )
+    },
+  ],
+  argTypes: {},
+}
+export default meta
+
+type Story = StoryObj<typeof ScheduleBadge>
+
+export const Red: Story = {
+  args: { color: 'RED', children: '일정' },
+}
+
+export const Yellow: Story = {
+  args: {
+    color: 'YELLOW',
+    children: '제목이 긴 일정제목이 긴 일정제목이 긴 일정제목이 긴 일정제목이 긴 일정제목이 긴 일정',
+  },
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #278 

ㅤ

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

shared/calendar-ui 스토리북 작성
ㅤ

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

ㅤ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * AppointmentBadge, CalendarCell, HeaderButton, HeaderMonthLabel, InfiniteCalendar, MonthlyCalendar, PrivateScheduleBadge, PrivateScheduleModal, RenderScheduleBadges, ScheduleBadge 컴포넌트에 대한 Storybook 스토리가 추가되었습니다.
  * 각 스토리는 다양한 색상, 날짜, 상태, 캘린더 유형 등 다양한 상황을 시각적으로 확인할 수 있도록 구성되었습니다.
  * 일부 스토리에서는 모달 열기, 월 이동 등 인터랙션을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->