### PR TITLE
refactor: [#299] 로그인 및 회원가입 페이지 수정

### DIFF
--- a/src/features/auth/signin/ui/email-signin-modal.tsx
+++ b/src/features/auth/signin/ui/email-signin-modal.tsx
@@ -1,4 +1,6 @@
-import { ModalContent, ModalOverlay, ModalPortal, Modal, ModalTitle, Text } from '@/shared/ui'
+import { ModalContent, ModalOverlay, ModalPortal, Modal, ModalTitle } from '@/shared/ui'
+
+import { PromptSwitch } from '../../ui'
 
 import SigninForm from './signin-form'
 
@@ -17,22 +19,8 @@ export default function EmailSigninModal({ isOpen, setSwitchModal, setClose }: P
         <ModalOverlay />
         <ModalContent>
           <ModalTitle className="text-center">로그인</ModalTitle>
-
           <SigninForm onSigninSuccess={() => setSwitchModal(null)} />
-
-          {/* TODO 컴포넌트화
-            NOTE 모달 어떻게 열지 */}
-          <Text typography="b2-normal" className="text-gray-80 flex gap-1 items-center justify-center mt-6">
-            <span>캘픽이 처음이신가요?</span>
-            <Text
-              as="button"
-              typography="b2-heading"
-              onClick={() => setSwitchModal('Signup')}
-              className="text-primary-80 underline decoration-solid decoration-2 decoration-skip-ink underline-offset-4"
-            >
-              회원가입
-            </Text>
-          </Text>
+          <PromptSwitch type="signin" to="/auth/signup" className="mt-6" />
         </ModalContent>
       </ModalPortal>
     </Modal>

--- a/src/features/auth/signin/ui/login-select-modal.tsx
+++ b/src/features/auth/signin/ui/login-select-modal.tsx
@@ -1,5 +1,7 @@
 import { ModalContent, ModalOverlay, ModalPortal, Modal, ModalTitle, Text } from '@/shared/ui'
 
+import { PromptSwitch } from '../../ui'
+
 import type { AuthModalType } from '../../types'
 
 interface Props {
@@ -34,19 +36,7 @@ export default function LoginSelectModal({ isOpen, setSwitchModal, setClose }: P
               이메일 로그인
             </Text>
           </div>
-          {/* TODO 컴포넌트화
-                NOTE 모달 어떻게 열지 */}
-          <Text typography="b2-normal" className="text-gray-80 flex gap-1 items-center justify-center mt-6">
-            <span>캘픽이 처음이신가요?</span>
-            <Text
-              as="button"
-              typography="b2-heading"
-              onClick={() => setSwitchModal('Signup')}
-              className="text-primary-80 underline decoration-solid decoration-2 decoration-skip-ink underline-offset-4"
-            >
-              회원가입
-            </Text>
-          </Text>
+          <PromptSwitch type="signin" to="/auth/signup" className="mt-6" />
         </ModalContent>
       </ModalPortal>
     </Modal>

--- a/src/features/auth/signin/ui/signin-form.tsx
+++ b/src/features/auth/signin/ui/signin-form.tsx
@@ -8,7 +8,7 @@ import { SigninSchema, useSigninMutation, type SigninFormDataType } from '../mod
 export default function SigninForm({ onSigninSuccess, isPage }: { onSigninSuccess?: () => void; isPage?: boolean }) {
   const methods = useForm<SigninFormDataType>({
     resolver: zodResolver(SigninSchema),
-    mode: 'onTouched',
+    mode: 'onChange',
   })
 
   const {

--- a/src/features/auth/signin/ui/signin-form.tsx
+++ b/src/features/auth/signin/ui/signin-form.tsx
@@ -5,10 +5,10 @@ import { Form, FormField, FormFieldWrapper, FormLabel, Button, Input, PasswordIn
 
 import { SigninSchema, useSigninMutation, type SigninFormDataType } from '../model'
 
-export default function SigninForm({ onSigninSuccess }: { onSigninSuccess?: () => void }) {
+export default function SigninForm({ onSigninSuccess, isPage }: { onSigninSuccess?: () => void; isPage?: boolean }) {
   const methods = useForm<SigninFormDataType>({
     resolver: zodResolver(SigninSchema),
-    mode: 'onChange', // NOTE: 'onChange' 과 'onSubmit'중에 어떤게 나을지
+    mode: 'onTouched',
   })
 
   const {
@@ -29,7 +29,7 @@ export default function SigninForm({ onSigninSuccess }: { onSigninSuccess?: () =
 
   return (
     <Form methods={methods} onSubmit={handleSubmit}>
-      <FormFieldWrapper>
+      <FormFieldWrapper isPage={isPage}>
         <FormField name="email">
           <FormLabel>이메일</FormLabel>
           <Input placeholder="이메일을 입력하세요" />

--- a/src/features/auth/signup/ui/signup-modal.tsx
+++ b/src/features/auth/signup/ui/signup-modal.tsx
@@ -1,4 +1,4 @@
-import { ModalContent, ModalOverlay, ModalPortal, Modal, ModalTitle, Text } from '@/shared/ui'
+import { ModalContent, ModalOverlay, ModalPortal, Modal, ModalTitle } from '@/shared/ui'
 
 import { PromptSwitch } from '../../ui'
 
@@ -21,11 +21,7 @@ export default function SignupModal({ isSignupOpen, setSwitchModal, setClose }: 
           <ModalTitle className="text-center">회원가입</ModalTitle>
           <SignupForm onSignupSuccess={() => setSwitchModal('EmailLogin')} />
 
-          <Text typography="b2-normal" className="text-gray-80 flex gap-1 items-center justify-center mt-6">
-            <span>이미 회원이신가요?</span>
-
-            <PromptSwitch type="signup" to="/auth/signin" className="mt-6" />
-          </Text>
+          <PromptSwitch type="signup" to="/auth/signin" className="mt-6" />
         </ModalContent>
       </ModalPortal>
     </Modal>

--- a/src/features/auth/signup/ui/signup-modal.tsx
+++ b/src/features/auth/signup/ui/signup-modal.tsx
@@ -1,5 +1,7 @@
 import { ModalContent, ModalOverlay, ModalPortal, Modal, ModalTitle, Text } from '@/shared/ui'
 
+import { PromptSwitch } from '../../ui'
+
 import SignupForm from './signup-form'
 
 import type { AuthModalType } from '../../types'
@@ -22,16 +24,7 @@ export default function SignupModal({ isSignupOpen, setSwitchModal, setClose }: 
           <Text typography="b2-normal" className="text-gray-80 flex gap-1 items-center justify-center mt-6">
             <span>이미 회원이신가요?</span>
 
-            {/* TODO 컴포넌트화
-          NOTE 모달 어떻게 열지 */}
-            <Text
-              as="button"
-              typography="b2-heading"
-              onClick={() => setSwitchModal('EmailLogin')}
-              className="text-primary-80 underline decoration-solid decoration-2 decoration-skip-ink underline-offset-4"
-            >
-              로그인
-            </Text>
+            <PromptSwitch type="signup" to="/auth/signin" className="mt-6" />
           </Text>
         </ModalContent>
       </ModalPortal>

--- a/src/features/auth/ui/index.ts
+++ b/src/features/auth/ui/index.ts
@@ -1,0 +1,1 @@
+export { default as PromptSwitch } from './prompt-switch'

--- a/src/features/auth/ui/prompt-switch.tsx
+++ b/src/features/auth/ui/prompt-switch.tsx
@@ -1,0 +1,37 @@
+import { Link } from 'react-router'
+
+import { Text } from '@/shared/ui'
+import { cn } from '@/shared/utils'
+
+interface Props {
+  type: 'signin' | 'signup'
+  to: string
+  className?: string
+}
+
+const prompts = {
+  signin: '캘픽이 처음이신가요?',
+  signup: '이미 회원이신가요?',
+}
+
+const texts = {
+  signin: '회원가입',
+  signup: '로그인',
+}
+
+export default function PromptSwitch({ type, to, className }: Props) {
+  return (
+    <div className={cn('flex items-center gap-1 text-center justify-center', className)}>
+      <Text typography="b2-normal" className="text-gray-80">
+        {prompts[type]}
+      </Text>
+      <Text
+        as="span"
+        typography="b2-heading"
+        className="text-primary-80 underline decoration-solid decoration-2 decoration-skip-ink underline-offset-4"
+      >
+        <Link to={to}>{texts[type]}</Link>
+      </Text>
+    </div>
+  )
+}

--- a/src/pages/auth/auth-layout.tsx
+++ b/src/pages/auth/auth-layout.tsx
@@ -1,12 +1,19 @@
-import { Outlet } from 'react-router'
+import { Outlet, Navigate } from 'react-router'
+
+import { useUserStore } from '@/entities/user'
+import { GNB } from '@/shared/ui'
 
 export default function AuthLayout() {
-  return (
-    <div>
-      {/* TODO 로그인, 회원가입 페이지 디자인 나오면 레이아웃 수정 */}
-      <main className="mx-4 mt-20">
+  const { user } = useUserStore()
+
+  return user ? (
+    <Navigate to="/" />
+  ) : (
+    <div className="flex justify-center lg:px-8 bg-gray-5 h-[100vh]">
+      <div className="w-full max-w-[640px] bg-white relative overflow-hidden">
+        <GNB rightSlot={<div />} sidebar={<div />} />
         <Outlet />
-      </main>
+      </div>
     </div>
   )
 }

--- a/src/pages/auth/signin/signin-page.tsx
+++ b/src/pages/auth/signin/signin-page.tsx
@@ -1,21 +1,17 @@
-import { Link } from 'react-router'
-
-import SigninForm from '@/features/auth/signin/ui/signin-form'
-import Text from '@/shared/ui/text/text'
+import { SigninForm } from '@/features/auth/signin/ui'
+import { PromptSwitch } from '@/features/auth/ui'
+import { Header, PageBackButton } from '@/shared/ui'
 
 export default function SigninPage() {
   return (
-    <div className="flex flex-col">
-      <Text as="h1" typography="h1-heading" className="text-center">
-        이메일 로그인
-      </Text>
-      <SigninForm />
-      <Link
-        to="/auth/signup"
-        className="text-center mt-4 underline text-primary-80 decoration-solid decoration-2 decoration-skip-ink underline-offset-4"
-      >
-        회원가입
-      </Link>
-    </div>
+    <>
+      <Header onNavigate={<PageBackButton />} onClick={<div />}>
+        로그인
+      </Header>
+      <div className="flex flex-col mx-4 mt-12">
+        <SigninForm isPage />
+        <PromptSwitch type="signin" to="/auth/signup" className="mt-6" />
+      </div>
+    </>
   )
 }

--- a/src/pages/auth/signup/signup-page.tsx
+++ b/src/pages/auth/signup/signup-page.tsx
@@ -1,21 +1,17 @@
-import { Link } from 'react-router'
-
 import SignupForm from '@/features/auth/signup/ui/signup-form'
-import Text from '@/shared/ui/text/text'
+import { PromptSwitch } from '@/features/auth/ui'
+import { Header, PageBackButton } from '@/shared/ui'
 export default function SignupPage() {
   return (
-    <div className="flex flex-col">
-      <Text as="h1" typography="h1-heading" className="text-center">
+    <>
+      <Header onNavigate={<PageBackButton />} onClick={<div />}>
         회원가입
-      </Text>
-      <SignupForm />
+      </Header>
+      <div className="flex flex-col mx-4 mt-12">
+        <SignupForm />
 
-      <Link
-        to="/auth/signin"
-        className="text-center mt-4 underline text-primary-80 decoration-solid decoration-2 decoration-skip-ink underline-offset-4"
-      >
-        이메일로그인
-      </Link>
-    </div>
+        <PromptSwitch type="signup" to="/auth/signin" className="mt-6" />
+      </div>
+    </>
   )
 }

--- a/src/shared/ui/form/form-field-wrapper.tsx
+++ b/src/shared/ui/form/form-field-wrapper.tsx
@@ -2,6 +2,10 @@ import { cn } from '@/shared/utils'
 
 import type { HTMLAttributes } from 'react'
 
-export default function FormFieldWrapper({ children, className }: HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn('flex flex-col gap-4 mb-6', className)}>{children}</div>
+interface Props extends HTMLAttributes<HTMLDivElement> {
+  isPage?: boolean
+}
+
+export default function FormFieldWrapper({ children, isPage, className }: Props) {
+  return <div className={cn('flex flex-col', isPage ? 'gap-10 mb-12' : 'gap-4 mb-6', className)}>{children}</div>
 }

--- a/src/shared/ui/gnb/logo.tsx
+++ b/src/shared/ui/gnb/logo.tsx
@@ -1,13 +1,11 @@
+import { Link } from 'react-router'
+
 import { IconLogo } from '@/shared/assets/icons'
-/**
- * 라우터 설정 후 a -> Link로 변경
- * @returns
- */
 
 export default function Logo() {
   return (
-    <a href={'/'}>
+    <Link to="/">
       <IconLogo className="w-16" />
-    </a>
+    </Link>
   )
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

- close #299

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 로그인 회원가입 페이지 레이아웃 수정
- 로그인 되어있을 경우 로그인/회원가입 페이지 접근 안되도록 레이아웃 처리

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요


## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

ㅤ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 인증 플로우에서 로그인/회원가입 전환을 위한 재사용 가능한 PromptSwitch 컴포넌트를 도입했습니다.

* **기능 개선**
  * 로그인 및 회원가입 모달과 페이지에서 기존 전환 버튼을 PromptSwitch 컴포넌트로 교체하여 UI 일관성을 높였습니다.
  * 인증 레이아웃(AuthLayout)에서 로그인된 사용자는 자동으로 메인 페이지로 리다이렉트됩니다.
  * FormFieldWrapper와 SigninForm에서 페이지별 스타일 및 동작을 위한 isPage 옵션을 추가했습니다.
  * 로고 클릭 시 React Router를 이용한 클라이언트 사이드 이동으로 변경되었습니다.

* **리팩터**
  * 인증 관련 페이지와 모달의 내부 구조 및 레이아웃을 개선하여 코드 가독성과 유지보수성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->