### PR TITLE
refactor: [#308] 알림 리스트 디자인 수정 및 에러 로딩 처리

### DIFF
--- a/src/features/notification/ui/fallback-notification-list.tsx
+++ b/src/features/notification/ui/fallback-notification-list.tsx
@@ -1,0 +1,21 @@
+import { Text } from '@/shared/ui'
+
+function FallbackNotificationList({ reset }: { reset: () => void }) {
+  return (
+    <div className="absolute z-dropdown top-4 -right-20 m-4 h-68 rounded-2xl w-fit sm:w-96 bg-white shadow-2xl p-4 whitespace-nowrap">
+      <Text as="h2" typography="b1-heading" className="mb-4">
+        캘픽 알림
+      </Text>
+      <div className="flex flex-col items-center h-48 justify-center">
+        <Text as="span" typography="label">
+          알림 리스트를 불러오지 못했습니다
+        </Text>
+        <Text as="button" onClick={reset} typography="label" className="hover:underline hover:underline-offset-4">
+          다시시도
+        </Text>
+      </div>
+    </div>
+  )
+}
+
+export default FallbackNotificationList

--- a/src/features/notification/ui/notification-bell.tsx
+++ b/src/features/notification/ui/notification-bell.tsx
@@ -1,15 +1,18 @@
 import { useRef, useState } from 'react'
+import { ErrorBoundary } from 'react-error-boundary'
 
 import { IconNotification, IconNotificationAlert } from '@/shared/assets'
 import { useClickOutside } from '@/shared/hooks'
 
+import FallbackNotificationList from './fallback-notification-list'
+import { NotificationProvider } from './notification-context'
 import NotificationList from './notification-list'
 
 export default function NotificationBell() {
   const [isOpen, setIsOpen] = useState<boolean>(false)
 
   // TODO: 알림 읽음 처리 후 수정 / 현재는 임시값
-  const hasUnreadNotifications = true
+  const hasUnreadNotifications = false
 
   const handleClick = () => {
     setIsOpen((prev) => !prev)
@@ -19,11 +22,19 @@ export default function NotificationBell() {
   useClickOutside(ref, () => setIsOpen(false))
 
   return (
-    <div className="relative" ref={ref}>
-      <button className="flex items-center" onClick={handleClick}>
-        {hasUnreadNotifications ? <IconNotificationAlert /> : <IconNotification />}
-      </button>
-      {isOpen && <NotificationList />}
-    </div>
+    <NotificationProvider value={{ isOpen, onOpenChange: setIsOpen, onToggleChange: () => setIsOpen((prev) => !prev) }}>
+      <div className="relative" ref={ref}>
+        <button className="flex items-center" onClick={handleClick}>
+          {hasUnreadNotifications ? <IconNotificationAlert /> : <IconNotification />}
+        </button>
+        {isOpen && (
+          <ErrorBoundary
+            fallbackRender={({ resetErrorBoundary }) => <FallbackNotificationList reset={resetErrorBoundary} />}
+          >
+            <NotificationList />
+          </ErrorBoundary>
+        )}
+      </div>
+    </NotificationProvider>
   )
 }

--- a/src/features/notification/ui/notification-context.ts
+++ b/src/features/notification/ui/notification-context.ts
@@ -1,0 +1,11 @@
+import { createContextScope } from '@/shared/utils'
+
+const createNotificationContext = createContextScope()
+
+export interface NotificationContextValue {
+  isOpen: boolean
+  onOpenChange: (open: boolean) => void
+  onToggleChange: () => void
+}
+
+export const [NotificationProvider, useNotificationContext] = createNotificationContext<NotificationContextValue>()

--- a/src/features/notification/ui/notification-list-item.tsx
+++ b/src/features/notification/ui/notification-list-item.tsx
@@ -1,0 +1,41 @@
+import { Link } from 'react-router'
+
+import { Text } from '@/shared/ui'
+import { cn, formatDateTimeWithDay } from '@/shared/utils'
+
+import { useNotificationContext } from './notification-context'
+
+import type { Notification } from '@/entities/notification'
+
+export default function NotificationListItem({ notification }: { notification: Notification }) {
+  const isAppointment = notification.type === 'APPOINTMENT'
+  const { content, createdAt } = notification
+
+  const { onOpenChange } = useNotificationContext()
+
+  return (
+    <li key={createdAt} className="flex flex-col p-2 rounded-xl hover:bg-gray-1">
+      <Link to={isAppointment ? '/appointments' : '/friends'} onClick={() => onOpenChange(false)}>
+        <div className="flex items-center gap-2">
+          <Text
+            as="span"
+            typography="caption-10"
+            className={cn(
+              'py-0.5 px-2 w-fit rounded-xl',
+              isAppointment ? 'bg-calendar-red-alt' : 'bg-calendar-blue-alt text-calendar-blue',
+            )}
+          >
+            {isAppointment ? '약속' : '친구'}
+          </Text>
+          <Text as="span" typography="label" className="text-gray-80">
+            {content}
+          </Text>
+        </div>
+
+        <Text as="span" typography="label" className="text-gray-50">
+          {formatDateTimeWithDay(createdAt, undefined, false)}
+        </Text>
+      </Link>
+    </li>
+  )
+}

--- a/src/features/notification/ui/notification-list-skeleton.tsx
+++ b/src/features/notification/ui/notification-list-skeleton.tsx
@@ -1,0 +1,29 @@
+import { cn } from '@/shared/utils'
+
+function NotificationListItemSkeleton() {
+  return (
+    <li className="flex flex-col p-2 rounded-xl animate-pulse">
+      <div className="flex items-center gap-2">
+        {/* 카테고리 태그 */}
+        <div className={cn('py-0.5 px-4 w-14 h-5 rounded-xl bg-gray-color-10')} />
+        {/* 내용 */}
+        <div className="h-4 bg-gray-color-10 rounded w-2/3" />
+      </div>
+
+      {/* 날짜 */}
+      <div className="h-3 bg-gray-color-10 rounded w-20 mt-2" />
+    </li>
+  )
+}
+
+// eslint-disable-next-line react/no-multi-comp
+export default function NotificationListSkeleton({ count = 5 }: { count?: number }) {
+  return (
+    <ul className="overflow-y-auto h-48 flex flex-col gap-1">
+      {Array.from({ length: count }).map((_, idx) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <NotificationListItemSkeleton key={idx} />
+      ))}
+    </ul>
+  )
+}

--- a/src/features/notification/ui/notification-list.tsx
+++ b/src/features/notification/ui/notification-list.tsx
@@ -1,10 +1,13 @@
-import { forwardRef, type ComponentPropsWithoutRef } from 'react'
+import { forwardRef, Suspense, type ComponentPropsWithoutRef } from 'react'
 
 import { useIntersect } from '@/shared/hooks'
 import { Text } from '@/shared/ui'
-import { cn, formatRelativeDate } from '@/shared/utils'
+import { cn } from '@/shared/utils'
 
 import { useNotification } from '../model'
+
+import NotificationListItem from './notification-list-item'
+import NotificationListSkeleton from './notification-list-skeleton'
 
 // TODO 디자인 시안 나오면 디자인 수정
 const NotificationList = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<'div'>>(
@@ -27,32 +30,25 @@ const NotificationList = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<'di
       <div
         ref={ref}
         className={cn(
-          'absolute z-dropdown top-4 -right-20 m-4 h-64 w-96 rounded bg-white shadow-2xl p-4 whitespace-nowrap',
+          'absolute z-dropdown top-4 -right-20 m-4 h-68 rounded-2xl w-fit sm:w-96 bg-white shadow-2xl p-4 whitespace-nowrap',
           className,
         )}
         {...restProps}
       >
-        <Text as="h2" typography="b1-heading">
-          notification
+        <Text as="h2" typography="b1-heading" className="mb-4">
+          캘픽 알림
         </Text>
-        <ul className="overflow-y-auto h-48 scrollbar-hide flex flex-col gap-2">
-          {notifications.map((notification) => (
-            <li key={notification.createdAt} className="flex flex-col">
-              <Text as="span" typography="label">
-                {notification.type === 'APPOINTMENT' ? '약속' : '친구'}
-              </Text>
-              <div className="flex items-center justify-between">
-                <Text as="span" typography="label">
-                  {notification.content}
-                </Text>
-                <Text as="span" typography="label" className="text-gray-500">
-                  {formatRelativeDate(new Date(notification.createdAt))}
-                </Text>
-              </div>
-            </li>
-          ))}
-          <div className="h-[1px]" ref={observerRef} />
-        </ul>
+
+        <Suspense fallback={<NotificationListSkeleton />}>
+          <ul className="overflow-y-auto h-48 scrollbar-hide flex flex-col">
+            {notifications.map((notification, idx) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <NotificationListItem notification={notification} key={idx} />
+              // key값에 Idx값을 사용하면 안되는건 아는데 현재 백엔드에서 넘겨주는 데이터에 key값으로 사용할 고유한 데이터나 id가 없어서 임시로 Idx사용했습니다
+            ))}
+            <div className="h-[1px]" ref={observerRef} />
+          </ul>
+        </Suspense>
       </div>
     )
   },

--- a/src/shared/utils/format-date-time-with-day.ts
+++ b/src/shared/utils/format-date-time-with-day.ts
@@ -3,7 +3,7 @@ import { ko } from 'date-fns/locale'
 
 type Callback = (date: string, dayOfWeek: string) => string
 
-export function formatDateTimeWithDay(date: string | Date, callback?: Callback) {
+export function formatDateTimeWithDay(date: string | Date, callback?: Callback, isShowAmPm = true) {
   const formattedDate = format(date, 'yyyy.MM.dd')
   const formattedTime = format(date, 'HH:mm')
   const formattedAmPm = format(date, 'a', { locale: ko })
@@ -12,6 +12,10 @@ export function formatDateTimeWithDay(date: string | Date, callback?: Callback) 
 
   if (callback) {
     return callback(formattedDate, dayOfWeek)
+  }
+
+  if (!isShowAmPm) {
+    return `${formattedDate} ${formattedTime}`
   }
 
   return `${formattedDate} ${formattedAmPm} ${formattedTime} (${dayOfWeek})`


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

- close #308

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 알림 리스트 스타일 수정
- 알림 리스트 에러바운더리 처리 (에러 시 에러 페이지로 리다이렉트 되지 않고, fallback컴포넌트가 렌더링됨)
- 알림 리스트 suspense 처리(로딩 시 스켈레톤 컴포넌트 렌더링)

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

ㅤ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 알림 목록이 로드 실패 시 안내 메시지와 재시도 버튼이 표시되는 대체 화면이 추가되었습니다.
  * 알림 목록의 항목이 별도의 컴포넌트로 분리되어, 약속/친구 알림 유형별로 구분된 라벨과 날짜 정보가 제공됩니다.
  * 알림 목록 로딩 중에는 스켈레톤 UI가 표시됩니다.
  * 알림 벨 클릭 시 알림 목록이 오류 발생 시에도 안전하게 처리되도록 개선되었습니다.

* **개선 사항**
  * 알림 목록의 디자인이 개선되고, 반응형 레이아웃이 적용되었습니다.
  * 날짜 및 시간 포맷 함수에 AM/PM 표시 여부를 선택할 수 있는 옵션이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->