### PR TITLE
refactor: kakao 로그인 리다이렉트 처리

### DIFF
--- a/src/pages/oauth/kakao-redirect-page.tsx
+++ b/src/pages/oauth/kakao-redirect-page.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { useSearchParams } from 'react-router'
+import { useNavigate, useSearchParams } from 'react-router'
 
 import useKakaoSigninMutation from '@/features/oauth/kakao/model/use-kakao-signin-mutation'
 // 배럴 패턴으로 import 하면 에러 떠서 실제 경로로 import했어요
@@ -10,9 +10,15 @@ export default function KaKaoRedirectPage() {
 
   const kakaoSigninMutation = useKakaoSigninMutation()
 
+  const navigate = useNavigate()
+
   useEffect(() => {
     if (code) {
-      kakaoSigninMutation.mutate(code)
+      kakaoSigninMutation.mutate(code, {
+        onSuccess: () => {
+          navigate('/')
+        },
+      })
     }
   }, [code])
 

--- a/src/pages/private-route.tsx
+++ b/src/pages/private-route.tsx
@@ -4,6 +4,7 @@ import { useUserStore } from '@/entities/user/models/use-user-store'
 
 export default function PrivateRoute() {
   const user = useUserStore((state) => !!state.user)
+  const hasToken = !!localStorage.getItem('token')
 
-  return user ? <Outlet /> : <Navigate to="/" />
+  return user || hasToken ? <Outlet /> : <Navigate to="/" />
 }

--- a/src/shared/api/axios-instance.ts
+++ b/src/shared/api/axios-instance.ts
@@ -2,6 +2,8 @@ import axios from 'axios'
 
 import { devLog } from '@/shared/utils/dev-log'
 
+import { toast } from '../ui'
+
 const API_BASE_URL = import.meta.env.VITE_API_URL
 const REQUEST_TIMEOUT = Number(import.meta.env.VITE_API_TIMEOUT) || 7000
 
@@ -49,7 +51,10 @@ axiosInstance.interceptors.response.use(
     if (status === 401) {
       // 토큰 만료 및 미인증
       localStorage.removeItem('token')
-      devLog('error', '권한이 없습니다')
+      localStorage.removeItem('user')
+      window.location.href = '/auth/signin'
+      toast.error('로그인 정보가 만료되었습니다. 다시 로그인해주세요.')
+      return
     } else if (status === 403) {
       // 로그인됐으나 권한 x
       devLog('error', '접근 권한이 없습니다', error)
@@ -59,6 +64,7 @@ axiosInstance.interceptors.response.use(
     } else if (status >= 500) {
       // 백엔드 내부 오류
       devLog('error', '서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.')
+      toast.error('서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.')
     }
 
     return Promise.reject(error)


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 카카오 리다이렉트 처리
- 토큰 만료 시 페이지 리다이렉트 처리

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

ㅤ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 카카오 로그인 성공 시 자동으로 메인 페이지로 이동하도록 개선되었습니다.

* **버그 수정**
  * 인증 만료(401) 시 로그인 세션 만료 안내 토스트가 표시되고, 로그인 페이지로 자동 이동됩니다.
  * 서버 오류(5xx) 발생 시 서버 문제 안내 토스트가 표시됩니다.

* **리팩터**
  * 로그인 상태 확인 시 사용자 정보뿐만 아니라 토큰 유무도 함께 확인하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->