### PR TITLE
refactor: [#308] 알림 리스트 스켈레톤 처리

### DIFF
--- a/src/features/auth/signin/model/use-signin-mutation.ts
+++ b/src/features/auth/signin/model/use-signin-mutation.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { useUserStore } from '@/entities/user'
+import { appointmentsQuery } from '@/features/appointment/models'
 import { friendQueryKeys } from '@/features/friends/model'
 import { toast } from '@/shared/ui'
 
@@ -18,6 +19,7 @@ function useSigninMutation() {
     onSuccess: (res) => {
       setUser(res)
       queryClient.invalidateQueries({ queryKey: friendQueryKeys.all })
+      queryClient.invalidateQueries({ queryKey: appointmentsQuery.all })
     },
     onError: (error: AxiosError) => {
       if (error?.status === 401) {

--- a/src/features/notification/ui/notification-bell.tsx
+++ b/src/features/notification/ui/notification-bell.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { Suspense, useRef, useState } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 
 import { IconNotification, IconNotificationAlert } from '@/shared/assets'
@@ -7,6 +7,7 @@ import { useClickOutside } from '@/shared/hooks'
 import FallbackNotificationList from './fallback-notification-list'
 import { NotificationProvider } from './notification-context'
 import NotificationList from './notification-list'
+import NotificationListSkeleton from './notification-list-skeleton'
 
 export default function NotificationBell() {
   const [isOpen, setIsOpen] = useState<boolean>(false)
@@ -31,7 +32,9 @@ export default function NotificationBell() {
           <ErrorBoundary
             fallbackRender={({ resetErrorBoundary }) => <FallbackNotificationList reset={resetErrorBoundary} />}
           >
-            <NotificationList />
+            <Suspense fallback={<NotificationListSkeleton />}>
+              <NotificationList />
+            </Suspense>
           </ErrorBoundary>
         )}
       </div>

--- a/src/features/notification/ui/notification-list-item.tsx
+++ b/src/features/notification/ui/notification-list-item.tsx
@@ -26,7 +26,7 @@ export default function NotificationListItem({ notification }: { notification: N
             typography="caption-10"
             className={cn(
               'py-0.5 px-2 w-fit rounded-xl',
-              isAppointment ? 'bg-calendar-red-alt' : 'bg-calendar-blue-alt text-calendar-blue',
+              isAppointment ? 'bg-calendar-red-alt text-calendar-red' : 'bg-calendar-blue-alt text-calendar-blue',
             )}
           >
             {isAppointment ? '약속' : '친구'}

--- a/src/features/notification/ui/notification-list-item.tsx
+++ b/src/features/notification/ui/notification-list-item.tsx
@@ -14,8 +14,12 @@ export default function NotificationListItem({ notification }: { notification: N
   const { onOpenChange } = useNotificationContext()
 
   return (
-    <li key={createdAt} className="flex flex-col p-2 rounded-xl hover:bg-gray-1">
-      <Link to={isAppointment ? '/appointments' : '/friends'} onClick={() => onOpenChange(false)}>
+    <li className="flex flex-col p-2 rounded-xl hover:bg-gray-1">
+      <Link
+        to={isAppointment ? '/appointments' : '/friends'}
+        onClick={() => onOpenChange(false)}
+        aria-label={`${isAppointment ? '약속' : '친구'} 알림: ${content}`}
+      >
         <div className="flex items-center gap-2">
           <Text
             as="span"

--- a/src/features/notification/ui/notification-list-skeleton.tsx
+++ b/src/features/notification/ui/notification-list-skeleton.tsx
@@ -1,29 +1,41 @@
+import { Text } from '@/shared/ui'
 import { cn } from '@/shared/utils'
 
 function NotificationListItemSkeleton() {
   return (
-    <li className="flex flex-col p-2 rounded-xl animate-pulse">
-      <div className="flex items-center gap-2">
-        {/* 카테고리 태그 */}
-        <div className={cn('py-0.5 px-4 w-14 h-5 rounded-xl bg-gray-color-10')} />
-        {/* 내용 */}
-        <div className="h-4 bg-gray-color-10 rounded w-2/3" />
+    <li className="flex flex-col p-2 rounded-xl">
+      <div className="flex items-center gap-2 animate-pulse">
+        {/* 태그 영역 */}
+        <div className="h-4 w-10 rounded-xl bg-gray-5" />
+
+        {/* 알림 내용 */}
+        <div className="h-4 flex-1 rounded bg-gray-5" />
       </div>
 
-      {/* 날짜 */}
-      <div className="h-3 bg-gray-color-10 rounded w-20 mt-2" />
+      {/* 날짜 영역 */}
+      <div className="mt-1 h-4 w-20 rounded bg-gray-5 animate-pulse" />
     </li>
   )
 }
 
 // eslint-disable-next-line react/no-multi-comp
-export default function NotificationListSkeleton({ count = 5 }: { count?: number }) {
+export default function NotificationListSkeleton() {
+  const count = 6
   return (
-    <ul className="overflow-y-auto h-48 flex flex-col gap-1">
-      {Array.from({ length: count }).map((_, idx) => (
-        // eslint-disable-next-line react/no-array-index-key
-        <NotificationListItemSkeleton key={idx} />
-      ))}
-    </ul>
+    <div
+      className={cn(
+        'absolute z-dropdown top-4 -right-20 m-4 h-68 rounded-2xl w-fit sm:w-96 bg-white shadow-2xl p-4 whitespace-nowrap scrollbar-hide',
+      )}
+    >
+      <Text as="h2" typography="b1-heading" className="mb-4">
+        캘픽 알림
+      </Text>
+      <ul className="overflow-y-auto h-48 flex flex-col gap-1">
+        {Array.from({ length: count }).map((_, idx) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <NotificationListItemSkeleton key={idx} />
+        ))}
+      </ul>
+    </div>
   )
 }

--- a/src/features/notification/ui/notification-list.tsx
+++ b/src/features/notification/ui/notification-list.tsx
@@ -41,10 +41,11 @@ const NotificationList = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<'di
 
         <Suspense fallback={<NotificationListSkeleton />}>
           <ul className="overflow-y-auto h-48 scrollbar-hide flex flex-col">
-            {notifications.map((notification, idx) => (
-              // eslint-disable-next-line react/no-array-index-key
-              <NotificationListItem notification={notification} key={idx} />
-              // key값에 Idx값을 사용하면 안되는건 아는데 현재 백엔드에서 넘겨주는 데이터에 key값으로 사용할 고유한 데이터나 id가 없어서 임시로 Idx사용했습니다
+            {notifications.map((notification) => (
+              <NotificationListItem
+                notification={notification}
+                key={`${notification.createdAt}-${notification.content.slice(0, 20)}`}
+              />
             ))}
             <div className="h-[1px]" ref={observerRef} />
           </ul>

--- a/src/index.css
+++ b/src/index.css
@@ -58,7 +58,6 @@
 :root {
   font-family: Pretendard;
   -webkit-font-smoothing: antialiased;
-  white-space: nowrap;
 
   /************/
   /** colors **/

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -23,7 +23,7 @@ export default function Home() {
     }
   }
 
-  useIntroGuide()
+  useIntroGuide(!!user)
   return (
     <>
       <Outlet />

--- a/src/shared/hooks/use-intro-guide.ts
+++ b/src/shared/hooks/use-intro-guide.ts
@@ -1,9 +1,14 @@
 import introJs from 'intro.js'
 import { useEffect } from 'react'
+
 import 'intro.js/introjs.css'
 
-function useIntroGuide() {
+function useIntroGuide(loggedIn: boolean) {
   useEffect(() => {
+    if (!loggedIn) {
+      return
+    }
+
     const isMainVisited = localStorage.getItem('main-visited')
     if (isMainVisited) {
       return
@@ -54,7 +59,7 @@ function useIntroGuide() {
         intro.exit()
       }
     }
-  }, [])
+  }, [loggedIn])
 }
 
 export default useIntroGuide

--- a/src/shared/ui/header/header.tsx
+++ b/src/shared/ui/header/header.tsx
@@ -12,7 +12,7 @@ export default function Header({ onNavigate, children, onClick }: Props) {
   return (
     <nav className="px-5 h-[3.25rem] border-b border-b-gray-10">
       <div className="flex items-center justify-between h-full">
-        <div className="w-4">{onNavigate}</div>
+        <div className="w-4 whitespace-nowrap">{onNavigate}</div>
         <Text typography="h2-heading" as="span">
           {children}
         </Text>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

- close #308

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- suspense 위치 변경
- 인트로 가이드 첫 접속이더라도 로그인 했을 경우에만 뜨도록 수정

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [x] suspense 처리를 부모 컴포넌트에서 위치하도록 수정


## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

ㅤ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능 및 개선**
  * 알림 벨 클릭 시 로드 중 스켈레톤 UI가 표시되도록 개선되었습니다.
  * 알림 스켈레톤 레이아웃과 제목("캘픽 알림")이 시각적으로 개선되었습니다.
  * 알림 목록의 항목 식별 방식이 더 안정적으로 변경되어 목록 안정성이 향상되었습니다.
  * 인트로 가이드가 로그인 여부에 따라 동작합니다.

* **접근성 개선**
  * 알림 항목에 aria-label이 추가되었습니다.

* **백그라운드 데이터 업데이트**
  * 로그인 후 약속 데이터가 자동으로 갱신되도록 업데이트되었습니다.

* **스타일**
  * 일부 레이아웃 및 줄바꿈 관련 스타일이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->