### PR TITLE
refactor: [#325] 빈 배열일 경우 이미지 추가 및 친구 캘린더 쿼리스트링 추가

### DIFF
--- a/src/features/appointment/ui/appointment-list.tsx
+++ b/src/features/appointment/ui/appointment-list.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router'
 
+import { IconNonSchedule } from '@/shared/assets'
 import { useIntersect, useQueryParamValue } from '@/shared/hooks'
 import {
   SegmentedControl,
@@ -57,6 +58,7 @@ export default function AppointmentList() {
         <SegmentedControlContent value={status} className="w-full flex flex-col gap-5 overflow-y-auto scrollbar-hide">
           {data.appointments.length === 0 ? (
             <div className="flex flex-col items-center py-6 gap-6 px-4 text-center">
+              <IconNonSchedule />
               <Text typography="b2-normal">{appointmentListEmptyMessage[status]}</Text>
             </div>
           ) : (

--- a/src/features/friends/ui/friend-item.tsx
+++ b/src/features/friends/ui/friend-item.tsx
@@ -27,7 +27,12 @@ export default function FriendItem({ friend }: { friend: Friend }) {
         {isEditMode ? (
           <DeleteFriendModal name={name} friendRequestId={friendRequestId} />
         ) : (
-          <Link to={`/friends/${friend.userId}/calendar?userName=${name}`}>
+          <Link
+            to={{
+              pathname: `/friends/${friend.userId}/calendar`,
+              search: new URLSearchParams({ userName: name }).toString(),
+            }}
+          >
             <IconCalendar />
           </Link>
         )}

--- a/src/features/friends/ui/friend-item.tsx
+++ b/src/features/friends/ui/friend-item.tsx
@@ -27,7 +27,7 @@ export default function FriendItem({ friend }: { friend: Friend }) {
         {isEditMode ? (
           <DeleteFriendModal name={name} friendRequestId={friendRequestId} />
         ) : (
-          <Link to={`/friends/${friend.userId}/calendar`}>
+          <Link to={`/friends/${friend.userId}/calendar?userName=${name}`}>
             <IconCalendar />
           </Link>
         )}

--- a/src/features/friends/ui/friend-list.tsx
+++ b/src/features/friends/ui/friend-list.tsx
@@ -1,3 +1,4 @@
+import { IconNonSchedule } from '@/shared/assets'
 import { useIntersect } from '@/shared/hooks'
 import { Text } from '@/shared/ui'
 
@@ -26,7 +27,7 @@ export default function FriendList() {
   if (friends.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-[calc(100vh-200px)] gap-4">
-        <div className="size-40 bg-gray-5" />
+        <IconNonSchedule />
         <Text as="span" typography="b2-normal" className="text-center">
           등록된 캘메이트가
           <br />

--- a/src/shared/ui/profile/profile-name.tsx
+++ b/src/shared/ui/profile/profile-name.tsx
@@ -1,3 +1,5 @@
+import { cn } from '@/shared/utils'
+
 import Text from '../text/text'
 
 import { useProfileContext } from './profile-context'
@@ -10,7 +12,7 @@ export default function Profilename({ className }: Props) {
   const { name } = useProfileContext()
 
   return (
-    <Text as="span" typography="b2-heading" className={className}>
+    <Text as="span" typography="b2-heading" className={cn('truncate', className)}>
       {name}
     </Text>
   )


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

- close #325

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 빈 리스트일 경우 이미지 추가
- 친구 캘린더로 이동할때 친구 이름 쿼리스트링에 추가
- 프로필 이름 truncate 속성 추가

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

ㅤ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 친구 캘린더로 이동 시 URL에 친구 이름(userName)이 쿼리로 포함되어 화면 맥락이 더 명확해졌습니다.

- Style
  - 약속 및 친구 목록의 빈 상태에 안내 아이콘이 추가되어 가독성이 향상되었습니다.
  - 프로필 이름에 항상 말줄임 처리(truncate)를 적용해 긴 이름으로 인한 레이아웃 깨짐을 방지했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->