### PR TITLE
feat: [#324] 약속 신청 후 navigate 수정

### DIFF
--- a/src/pages/create-schedule/appointment-schedule-page.tsx
+++ b/src/pages/create-schedule/appointment-schedule-page.tsx
@@ -79,7 +79,7 @@ export default function AppointmentSchedulePage() {
     try {
       const result = await appointmentScheduleMutate.mutateAsync(payload)
       devLog('log', 'result', result)
-      navigate('/')
+      navigate(isFriendScenario ? `/friends/${receiverId}/calendar/` : isShareScenario ? `/share/${receiverId}` : '0')
     } catch (error) {
       devLog('error', 'error', error)
       toast.error('약속 신청 중 오류가 발생했습니다.')


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #324 약속 신청 후 navigate 수정 

ㅤ

## 📝 작업 내용

> 약속 신청 후 메인 페이지로 넘어가던 것을 기존 캘린더에 그대로 머물도록 수정

ㅤ

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

ㅤ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 약속 일정 생성 후 이동 경로가 상황에 따라 달라집니다. 친구와 관련된 일정이면 해당 친구의 캘린더 페이지로 이동하고, 공유 시나리오에서는 공유 페이지로 안내합니다. 명확하지 않은 경우에는 기본 경로로 이동합니다. 이로써 일정 생성 직후 원하는 대상과 맥락에 맞는 화면으로 더 빠르게 접근할 수 있습니다. 불필요한 홈 화면 리디렉션이 줄어 사용 흐름이 자연스러워졌습니다. 제출과 오류 처리는 기존 동작을 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->