### PR TITLE
refactor: notification 리스트 비어있을 경우 조건부 렌더링 추가

### DIFF
--- a/src/features/notification/ui/notification-list.tsx
+++ b/src/features/notification/ui/notification-list.tsx
@@ -41,12 +41,18 @@ const NotificationList = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<'di
 
         <Suspense fallback={<NotificationListSkeleton />}>
           <ul className="overflow-y-auto h-48 scrollbar-hide flex flex-col">
-            {notifications.map((notification) => (
-              <NotificationListItem
-                notification={notification}
-                key={`${notification.createdAt}-${notification.content.slice(0, 20)}`}
-              />
-            ))}
+            {notifications.length === 0 ? (
+              <Text as="li" typography="label" className="w-full h-full flex items-center justify-center">
+                현재 알림이 없습니다
+              </Text>
+            ) : (
+              notifications.map((notification) => (
+                <NotificationListItem
+                  notification={notification}
+                  key={`${notification.createdAt}-${notification.content.slice(0, 20)}`}
+                />
+              ))
+            )}
             <div className="h-[1px]" ref={observerRef} />
           </ul>
         </Suspense>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

ㅤ

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

 알림 리스트 비어있을 경우 조건부 렌더링 추가

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

ㅤ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 빈 상태 안내 추가: 알림이 없을 때 목록 대신 중앙 정렬된 메시지 “현재 알림이 없습니다”를 표시합니다.
  * 기존 동작 유지: 알림이 있을 경우 이전과 동일하게 각 알림 항목이 표시됩니다.
  * 사용자 경험 개선: 비어있는 경우에도 명확한 피드백을 제공해 혼선을 줄이고 레이아웃 일관성을 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->