### PR TITLE
fix: [#333] 공유캘린더 이전달 스크롤 안되게 수정

### DIFF
--- a/src/pages/share-calendar/share-calendar-page.tsx
+++ b/src/pages/share-calendar/share-calendar-page.tsx
@@ -76,6 +76,7 @@ export default function ShareCalendarPage() {
         renderDay={(date) => <RenderScheduleBadges isShareCalendar date={date} scheduleMap={scheduleMap} />}
         buttonIcon={<IconInvite />}
         isPast={true}
+        disablePrev={true}
       />
     </>
   )

--- a/src/widgets/calendar/calendar-layout.tsx
+++ b/src/widgets/calendar/calendar-layout.tsx
@@ -20,6 +20,7 @@ interface Props {
   setMonths?: Dispatch<SetStateAction<Month[]>>
   renderDay?: (date: Date) => ReactNode // 셀 안에 표시될 컴포넌트들
   onCreateSchedule?: () => void //플로팅버튼 클릭시 실행되는 함수
+  disablePrev?: boolean
   buttonIcon?: ReactNode //플로팅 버튼 안에 표시될 아이콘
   children?: ReactNode
 }
@@ -34,6 +35,7 @@ export default function CalendarLayout({
   isPast,
   renderDay,
   onCreateSchedule,
+  disablePrev,
   buttonIcon,
   children,
 }: Props) {
@@ -49,7 +51,7 @@ export default function CalendarLayout({
           <ErrorFallback error={error} resetErrorBoundary={resetErrorBoundary} navigate={navigate} />
         )}
       >
-        <InfiniteCalendar months={months} setMonths={setMonths} isPast={isPast}>
+        <InfiniteCalendar months={months} setMonths={setMonths} isPast={isPast} disablePrev={disablePrev}>
           {renderDay}
         </InfiniteCalendar>
       </ErrorBoundary>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

- close #333 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 공유캘린더 이전달 스크롤 안되게 수정

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

ㅤ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 공유 캘린더 페이지에서 이전 날짜로의 이동이 비활성화되었습니다.
  * 캘린더가 ‘이전 이동 비활성화’ 옵션을 지원합니다. 옵션이 켜진 경우 오늘 이전 날짜 선택이 불가하며 이전 이동 컨트롤이 비활성화됩니다.
  * 기존 캘린더 동작(과거 여부 표시, 날짜 렌더링, 버튼 아이콘 등)은 변경 없이 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->