### PR TITLE
fix: [#335] 비로그인시 플로팅버튼 안보이도록 수정

### DIFF
--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -51,7 +51,7 @@ export default function Home() {
     <>
       <Outlet />
       {!user ? (
-        <CalendarLayout onDateClick={onDateClick}>
+        <CalendarLayout onDateClick={onDateClick} user={!user}>
           <SwitchModal
             switchModal={switchModal}
             setSwitchModal={setSwitchModal}

--- a/src/widgets/calendar/calendar-layout.tsx
+++ b/src/widgets/calendar/calendar-layout.tsx
@@ -20,7 +20,8 @@ interface Props {
   setMonths?: Dispatch<SetStateAction<Month[]>>
   renderDay?: (date: Date) => ReactNode // 셀 안에 표시될 컴포넌트들
   onCreateSchedule?: () => void //플로팅버튼 클릭시 실행되는 함수
-  disablePrev?: boolean
+  disablePrev?: boolean // 이전달
+  user?: boolean // 로그인여부
   buttonIcon?: ReactNode //플로팅 버튼 안에 표시될 아이콘
   children?: ReactNode
 }
@@ -36,6 +37,7 @@ export default function CalendarLayout({
   renderDay,
   onCreateSchedule,
   disablePrev,
+  user,
   buttonIcon,
   children,
 }: Props) {
@@ -56,9 +58,14 @@ export default function CalendarLayout({
         </InfiniteCalendar>
       </ErrorBoundary>
 
-      <FloatButton className="bg-primary-60" size="large" onClick={onCreateSchedule}>
-        {buttonIcon}
-      </FloatButton>
+      {user ? (
+        ''
+      ) : (
+        <FloatButton className="bg-primary-60" size="large" onClick={onCreateSchedule}>
+          {buttonIcon}
+        </FloatButton>
+      )}
+
       {children}
     </Calendar>
   )


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

ㅤ-close #335 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 메인페이지에서 비로그인시 플로팅버튼 안보이도록 수정
ㅤ

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

ㅤ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 캘린더 화면에서 로그인 상태에 따라 ‘일정 생성’ 플로팅 버튼 노출이 달라집니다. 비로그인 사용자는 버튼이 표시되어 빠르게 일정을 생성할 수 있고, 로그인 사용자는 버튼이 숨겨져 더 깔끔한 화면을 이용할 수 있습니다. 홈 화면의 비로그인 경로에도 이 동작이 반영되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->