### PR TITLE
feat: [#341] 약속/일정 등록 후 토스트 알림 추가

### DIFF
--- a/src/pages/create-schedule/appointment-schedule-page.tsx
+++ b/src/pages/create-schedule/appointment-schedule-page.tsx
@@ -79,6 +79,7 @@ export default function AppointmentSchedulePage() {
     try {
       const result = await appointmentScheduleMutate.mutateAsync(payload)
       devLog('log', 'result', result)
+      toast.success('약속이 신청되었습니다.')
       navigate(isFriendScenario ? `/friends/${receiverId}/calendar/` : isShareScenario ? `/share/${receiverId}` : '0')
     } catch (error) {
       devLog('error', 'error', error)

--- a/src/pages/create-schedule/register-detailed-schedule-page.tsx
+++ b/src/pages/create-schedule/register-detailed-schedule-page.tsx
@@ -53,6 +53,7 @@ export default function RegisterSchedulePage() {
       const result = await scheduleRegisterMutate.mutateAsync(payload)
       devLog('log', 'result', result)
       navigate('/')
+      toast.success('일정이 등록되었습니다.')
     } catch (error) {
       devLog('error', 'error', error)
       toast.error('일정 등록 중 오류가 발생했습니다.')

--- a/src/pages/create-schedule/register-schedule-page.tsx
+++ b/src/pages/create-schedule/register-schedule-page.tsx
@@ -53,6 +53,7 @@ export default function RegisterSchedulePage() {
       const result = await scheduleRegisterMutate.mutateAsync(payload)
       devLog('log', 'result', result)
       navigate('/')
+      toast.success('일정이 등록되었습니다.')
     } catch (error) {
       devLog('error', 'error', error)
       toast.error('일정 등록 중 오류가 발생했습니다.')


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #341 약속 신청 / 일정 등록 완료 시 토스트 알림 추가

ㅤ

## 📝 작업 내용

> 약속 신청 / 일정 등록 완료 시 토스트 알림 추가

ㅤ

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

ㅤ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 약속 신청 완료 시 성공 알림 토스트가 표시됩니다: “약속이 신청되었습니다.”
  - 일정 등록 완료 시 성공 알림 토스트가 표시됩니다: “일정이 등록되었습니다.” (일반 등록 및 상세 등록 흐름 모두 적용)

- 기타
  - 기존 화면 이동과 오류 알림 흐름은 변경 없이 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->