### PR TITLE
feat: [#340] 보낸 약속 거절/수락 알림 삭제

### DIFF
--- a/src/entities/appointment/models/appointment.types.ts
+++ b/src/entities/appointment/models/appointment.types.ts
@@ -52,4 +52,5 @@ export interface AppointmentDetail {
   inviteAt: string
   color: ColorType
   status: AppointmentRequestStatus
+  appointmentStatus: AppointmentStatus
 }

--- a/src/features/appointment/ui/appointment-detail.tsx
+++ b/src/features/appointment/ui/appointment-detail.tsx
@@ -1,7 +1,5 @@
 import { useNavigate, useParams, useSearchParams } from 'react-router'
 
-import { devLog } from '@/shared/utils'
-
 import useAppointmentById from '../models/use-appointment-by-id'
 import { useRespondToMyAppointmentRequest } from '../models/use-respond-to-my-appointment-request'
 
@@ -36,8 +34,6 @@ export default function AppointmentDetail() {
   const handleReject = (content: string) => {
     handleRespondToAppointment('REJECT', content)
   }
-
-  devLog('log', 'appointment', { appointment })
 
   return (
     <section>

--- a/src/features/appointment/ui/appointment-detail.tsx
+++ b/src/features/appointment/ui/appointment-detail.tsx
@@ -1,5 +1,7 @@
 import { useNavigate, useParams, useSearchParams } from 'react-router'
 
+import { useUserStore } from '@/entities/user'
+
 import useAppointmentById from '../models/use-appointment-by-id'
 import { useRespondToMyAppointmentRequest } from '../models/use-respond-to-my-appointment-request'
 
@@ -13,7 +15,9 @@ export default function AppointmentDetail() {
   const { id } = useParams()
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
-  const statusFromQuery = searchParams.get('status') as 'PENDING' | 'RESPONDED' | 'SENT' | null
+  const receiverName = searchParams.get('receiverName') as string
+  const user = useUserStore((state) => state.user)
+  const userName = user?.name
 
   if (!id) {
     throw new Error('요청하신 약속 페이지가 존재하지 않아요.')
@@ -40,11 +44,20 @@ export default function AppointmentDetail() {
       <AppointmentHeader>약속 상세</AppointmentHeader>
       <div className="flex flex-col gap-4 mx-4 mt-6">
         <AppointmentCard className="bg-gray-1 pt-4 pb-5">
-          <AppointmentSender
-            className="pb-3"
-            inviteAt={appointment.inviteAt}
-            requesterName={appointment.requesterName}
-          />
+          {receiverName === userName ? (
+            <AppointmentSender
+              className="pb-3"
+              inviteAt={appointment.inviteAt}
+              requesterName={appointment.requesterName}
+            >
+              From
+            </AppointmentSender>
+          ) : (
+            <AppointmentSender className="pb-3" inviteAt={appointment.inviteAt} requesterName={receiverName}>
+              To
+            </AppointmentSender>
+          )}
+
           <AppointmentOverview content={appointment.content} />
         </AppointmentCard>
 
@@ -55,7 +68,7 @@ export default function AppointmentDetail() {
             startAt={appointment.startAt}
             endAt={appointment.endAt}
           />
-          {statusFromQuery === 'PENDING' && (
+          {receiverName === userName && (
             <div className="flex">
               <AppointmentDetailRejectButton onReject={handleReject} />
               <AppointmentDetailAcceptButton onAccept={handleAccept} />

--- a/src/features/appointment/ui/appointment-detail.tsx
+++ b/src/features/appointment/ui/appointment-detail.tsx
@@ -1,4 +1,6 @@
-import { useNavigate, useParams } from 'react-router'
+import { useNavigate, useParams, useSearchParams } from 'react-router'
+
+import { devLog } from '@/shared/utils'
 
 import useAppointmentById from '../models/use-appointment-by-id'
 import { useRespondToMyAppointmentRequest } from '../models/use-respond-to-my-appointment-request'
@@ -12,6 +14,8 @@ import { AppointmentCard, AppointmentHeader, AppointmentOverview, AppointmentSch
 export default function AppointmentDetail() {
   const { id } = useParams()
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const statusFromQuery = searchParams.get('status') as 'PENDING' | 'RESPONDED' | 'SENT' | null
 
   if (!id) {
     throw new Error('요청하신 약속 페이지가 존재하지 않아요.')
@@ -33,6 +37,8 @@ export default function AppointmentDetail() {
     handleRespondToAppointment('REJECT', content)
   }
 
+  devLog('log', 'appointment', { appointment })
+
   return (
     <section>
       <AppointmentHeader>약속 상세</AppointmentHeader>
@@ -53,7 +59,7 @@ export default function AppointmentDetail() {
             startAt={appointment.startAt}
             endAt={appointment.endAt}
           />
-          {appointment.status === 'REQUESTED' && (
+          {statusFromQuery === 'PENDING' && (
             <div className="flex">
               <AppointmentDetailRejectButton onReject={handleReject} />
               <AppointmentDetailAcceptButton onAccept={handleAccept} />

--- a/src/features/appointment/ui/appointment-list-item.tsx
+++ b/src/features/appointment/ui/appointment-list-item.tsx
@@ -40,9 +40,21 @@ export default function AppointmentListItem({
   const isClickable = !isResponded && (canRespond || requesterName === currentUser?.name)
 
   return (
-    <Link to={`/appointments/requests/${id}?status=${status}`} className={!isClickable ? 'pointer-events-none' : ''}>
+    <Link
+      to={`/appointments/requests/${id}?receiverName=${receiverName}`}
+      className={!isClickable ? 'pointer-events-none' : ''}
+    >
       <AppointmentCard className="p-0" disabled={!isClickable}>
-        <AppointmentSender inviteAt={inviteAt} requesterName={requesterName} className="py-4 px-6 bg-gray-1" />
+        {status === 'SENT' ? (
+          <AppointmentSender inviteAt={inviteAt} requesterName={receiverName} className="py-4 px-6 bg-gray-1">
+            To
+          </AppointmentSender>
+        ) : (
+          <AppointmentSender inviteAt={inviteAt} requesterName={requesterName} className="py-4 px-6 bg-gray-1">
+            From
+          </AppointmentSender>
+        )}
+
         <div className="flex flex-col items-center gap-[0.188rem] py-6">
           <Text typography="b2-heading">{title}</Text>
           <div className="flex items-center gap-[0.313rem]">

--- a/src/features/appointment/ui/appointment-list-item.tsx
+++ b/src/features/appointment/ui/appointment-list-item.tsx
@@ -40,7 +40,7 @@ export default function AppointmentListItem({
   const isClickable = !isResponded && (canRespond || requesterName === currentUser?.name)
 
   return (
-    <Link to={`/appointments/requests/${id}`} className={!isClickable ? 'pointer-events-none' : ''}>
+    <Link to={`/appointments/requests/${id}?status=${status}`} className={!isClickable ? 'pointer-events-none' : ''}>
       <AppointmentCard className="p-0" disabled={!isClickable}>
         <AppointmentSender inviteAt={inviteAt} requesterName={requesterName} className="py-4 px-6 bg-gray-1" />
         <div className="flex flex-col items-center gap-[0.188rem] py-6">

--- a/src/features/appointment/ui/appointment-list.tsx
+++ b/src/features/appointment/ui/appointment-list.tsx
@@ -9,7 +9,6 @@ import {
   SegmentedControlList,
 } from '@/shared/ui/segmented-control'
 import Text from '@/shared/ui/text/text'
-import { devLog } from '@/shared/utils'
 
 import { appointmentListEmptyMessage } from '../consts/appointment-list-empty-message'
 import { useMyAppointmentsByStatus } from '../models'
@@ -41,9 +40,6 @@ export default function AppointmentList() {
   const handleStatusChange = (value: string) => {
     navigate(`/appointments?status=${value}`)
   }
-
-  devLog('log', 'apointment', { status })
-  devLog('log', 'apointment', { data })
 
   return (
     <div className="flex flex-col items-center py-6 gap-6 px-4 h-[calc(100vh-111px)]">

--- a/src/features/appointment/ui/appointment-list.tsx
+++ b/src/features/appointment/ui/appointment-list.tsx
@@ -9,6 +9,7 @@ import {
   SegmentedControlList,
 } from '@/shared/ui/segmented-control'
 import Text from '@/shared/ui/text/text'
+import { devLog } from '@/shared/utils'
 
 import { appointmentListEmptyMessage } from '../consts/appointment-list-empty-message'
 import { useMyAppointmentsByStatus } from '../models'
@@ -40,6 +41,9 @@ export default function AppointmentList() {
   const handleStatusChange = (value: string) => {
     navigate(`/appointments?status=${value}`)
   }
+
+  devLog('log', 'apointment', { status })
+  devLog('log', 'apointment', { data })
 
   return (
     <div className="flex flex-col items-center py-6 gap-6 px-4 h-[calc(100vh-111px)]">

--- a/src/features/appointment/ui/appointment-sender.tsx
+++ b/src/features/appointment/ui/appointment-sender.tsx
@@ -3,15 +3,21 @@ import { cn, formatDateToYMD } from '@/shared/utils'
 
 import type { Appointment } from '@/entities/appointment/models/appointment.types'
 
+interface Props {
+  className?: string
+  children?: string
+}
+
 export default function AppointmentSender({
   requesterName,
   inviteAt,
   className,
-}: Pick<Appointment, 'requesterName' | 'inviteAt'> & { className?: string }) {
+  children,
+}: Pick<Appointment, 'requesterName' | 'inviteAt'> & Props) {
   return (
     <div className={cn('flex justify-between items-center', className)}>
       <div className="flex items-center gap-[0.3125rem]">
-        <Text typography="b2-heading">From</Text>
+        <Text typography="b2-heading">{children}</Text>
         <Text typography="b2-normal">{requesterName}</Text>
       </div>
       <div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #340 보낸 약속 거절/수락 알림 삭제

ㅤ

## 📝 작업 내용

> 보낸 약속 상세페이지에서 거절/수락 버튼 제거
> 보낸 약속도 보낸 사람이 표기되던 부분을 받는 사람이 표기되도록 수정

ㅤ

## 📸 스크린샷 또는 GIF (선택)

> ui 컴포넌트 개발, 페이지 퍼블리싱을 했다면 스크린샷도 올려주세요

## 이번 pr을 올리기 전에 받은 피드백이 있나요? (있으면 체크리스트 작성)

수정한 피드백

- [ ]
- [ ]
- [ ]

수정 안 한 피드백

- [ ]
- [ ]
- [ ]ㅤ

## ✍🏻 참고사항

> 팀원들이 참고해야할 부분이 있다면 적어주세요

ㅤ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 예약 상세에 전체 상태를 나타내는 appointmentStatus 필드가 추가되어 상태 표현이 강화됩니다.
  - URL의 receiverName 쿼리로 송수신자 표시를 조정해, 상세·목록 간 표시 일관성이 향상됩니다.
  - 목록 링크에 receiverName을 포함해 상세 진입 시 올바른 송수신자 컨텍스트가 유지됩니다.
  - 액션 버튼(수락/거절)은 수신자일 때만 노출되도록 제어되어 권한 기반 UI가 개선됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->